### PR TITLE
Make the banner fit to 80column terminal.

### DIFF
--- a/src/COBREXA.jl
+++ b/src/COBREXA.jl
@@ -24,12 +24,12 @@ r = c[:bold] * c[:red]
 g = c[:bold] * c[:green]
 m = c[:bold] * c[:magenta]
 banner = "
-      ____ ___  ____  ____  _____$(g)__$(tx)  $(r)__$(tx)    _     |
-     / ___/ _ \\| __ )|  _ \\| ____$(g)\\ \\$(tx)$(r)/ /$(tx)   / \\    | Constraint-Based Reconstruction
-    | |  | | | |  _ \\| |_) |  _|  $(g)\\$(tx)  $(r)/$(tx)   / _ \\   | and EXascale Analysis in Julia
-    | |__| |_| | |_) |  _ <| |___ $(m)/$(tx)  $(b)\\$(tx)  / ___ \\  |
-     \\____\\___/|____/|_| \\_\\_____$(m)/_/$(tx)$(b)\\_\\$(tx)/_/   \\_\\ | Version: v$(COBREXA_VERSION)
-                                                 |
+   ____ ___  ____  ____  _____$(g)__$(tx)  $(r)__$(tx)    _     |
+  / ___/ _ \\| __ )|  _ \\| ____$(g)\\ \\$(tx)$(r)/ /$(tx)   / \\    | Constraint-Based Reconstruction
+ | |  | | | |  _ \\| |_) |  _|  $(g)\\$(tx)  $(r)/$(tx)   / _ \\   | and EXascale Analysis in Julia
+ | |__| |_| | |_) |  _ <| |___ $(m)/$(tx)  $(b)\\$(tx)  / ___ \\  |
+  \\____\\___/|____/|_| \\_\\_____$(m)/_/$(tx)$(b)\\_\\$(tx)/_/   \\_\\ | Version: v$(COBREXA_VERSION)
+                                              |
 "
 
 print(banner)


### PR DESCRIPTION
I hope the padding on the left wasn't really necessary.

# Description of the proposed change

This just moves the banner 3 letters to the left so the "ion" on the end of "reconstruction" doesn't overflow the 80cols and break the lovely logo on standard width terminal.

