### PR TITLE
Support wildcards in documentation building

### DIFF
--- a/docs/src/functions.md
+++ b/docs/src/functions.md
@@ -4,33 +4,33 @@
 
 ```@autodocs
 Modules = [COBREXA]
-Pages = map(file -> joinpath("types", file), readdir("types"))
+Pages = map(file -> joinpath("types", file), readdir("../src/types"))
 ```
 
 ## Base functions
 
 ```@autodocs
 Modules = [COBREXA]
-Pages = map(file -> joinpath("base", file), readdir("base"))
+Pages = map(file -> joinpath("base", file), readdir("../src/base"))
 ```
 
 ## File I/O and serialization
 
 ```@autodocs
 Modules = [COBREXA]
-Pages = map(file -> joinpath("io", file), readdir("io"))
+Pages = map(file -> joinpath("io", file), readdir("../src/io"))
 ```
 
 ## Model reconstruction
 
 ```@autodocs
 Modules = [COBREXA]
-Pages = map(file -> joinpath("reconstruction", file), readdir("reconstruction"))
+Pages = map(file -> joinpath("reconstruction", file), readdir("../src/reconstruction"))
 ```
 
 ## Analysis functions
 
 ```@autodocs
 Modules = [COBREXA]
-Pages = map(file -> joinpath("analysis", file), readdir("analysis"))
+Pages = map(file -> joinpath("analysis", file), readdir("../src/analysis"))
 ```


### PR DESCRIPTION
Because we now have wildcards in main module and tests, we should have them in docs too, right?

Closes #26
(as the sole purpose)

