### PR TITLE
Prepare accessors for genetic and chemical information

### DIFF
--- a/src/types/abstract/MetabolicModel.jl
+++ b/src/types/abstract/MetabolicModel.jl
@@ -123,13 +123,16 @@ end
 
 Return identifiers of all genes contained in the model. By default, there are
 no genes.
+
+In SBML, these are usually called "gene products" but we write `genes` for
+simplicity.
 """
 function genes(a::MetabolicModel)::Vector{String}
     return []
 end
 
 """
-    reaction_gene_product_association(a::MetabolicModel, gene_id::String)::Maybe{Vector{Vector{String}}}
+    reaction_gene_association(a::MetabolicModel, gene_id::String)::Maybe{Vector{Vector{String}}}
 
 Returns the sets of genes that need to be present so that the reaction can work
 (technically, a DNF on gene availability, with positive atoms only).
@@ -137,7 +140,7 @@ Returns the sets of genes that need to be present so that the reaction can work
 For simplicity, `nothing` may be returned, meaning that the reaction always
 takes place. (in DNF, that would be equivalent to returning `[[]]`.)
 """
-function reaction_gene_product_association(
+function reaction_gene_association(
     a::MetabolicModel,
     reaction_id::String,
 )::Maybe{Vector{Vector{String}}}


### PR DESCRIPTION
Aims:
- represent genes, formulas, etc. in a generic way
- make model conversion through the `MetabolicModel` interface lossless to some practical extent (e.g. SBML and JSON should be convertible to Standard using a single conversion function)
