### PR TITLE
New sparse type for bounds

### DIFF
--- a/src/base/sparse_bounds.jl
+++ b/src/base/sparse_bounds.jl
@@ -40,7 +40,7 @@ function sparse_bounds(arr, bound)
             push!(vs, a)
         end
     end
-    return SparseBoundVector{Float64, Int64}(n, bound, v_inds, vs, z_inds, b_inds)
+    return SparseBoundVector{Float64,Int64}(n, bound, v_inds, vs, z_inds, b_inds)
 end
 
 # Interface is very restricted since the data type is very unique


### PR DESCRIPTION
Investigating if it makes sense to define a special sparse representation for the bounds vector
