### PR TITLE
avoid uncertainty creep

### DIFF
--- a/src/base/types/StandardModel.jl
+++ b/src/base/types/StandardModel.jl
@@ -306,7 +306,7 @@ function Base.convert(::Type{StandardModel}, model::MetabolicModel)
         modelmetabolites[mid] = Metabolite(
             mid;
             charge = metabolite_charge(model, mid),
-            formula = _atoms_to_formula(metabolite_formula(model, mid)),
+            formula = maybemap(_atoms_to_formula, metabolite_formula(model, mid)),
             compartment = metabolite_compartment(model, mid),
             notes = metabolite_notes(model, mid),
             annotations = metabolite_annotations(model, mid),

--- a/src/base/utils/chemical_formulas.jl
+++ b/src/base/utils/chemical_formulas.jl
@@ -19,7 +19,3 @@ end
 function _atoms_to_formula(f::MetaboliteFormula)::String
     return join(["$elem$n" for (elem, n) in f])
 end
-
-function _atoms_to_formula(_::Nothing)::Nothing
-    return nothing
-end

--- a/src/base/utils/gene_associations.jl
+++ b/src/base/utils/gene_associations.jl
@@ -36,10 +36,6 @@ function _parse_grr(s::String)::GeneAssociation
     return gene_reaction_rules
 end
 
-function _parse_grr(_::Nothing)::Nothing
-    return nothing
-end
-
 """
     unparse_grr(grr::Vector{Vector{Gene}}
 
@@ -53,8 +49,4 @@ function _unparse_grr(grr::GeneAssociation)::String
     end
     grr_string = join(grr_strings, " or ")
     return grr_string
-end
-
-function _unparse_grr(_::Nothing)::Nothing
-    return nothing
 end

--- a/src/io/mat_writer.jl
+++ b/src/io/mat_writer.jl
@@ -38,7 +38,7 @@ function _write_mat_model(model::StandardModel, file_location::String)
         "rxnNames" => [r.name for r in model.reactions],
         "description" => model.id,
         "genes" => [g.id for g in model.genes],
-        "grRules" => [_unparse_grr(r.grr) for r in model.reactions],
+        "grRules" => [maybemap(_unparse_grr, r.grr) for r in model.reactions],
         "S" => Matrix(S),
         "metNames" => [m.name for m in model.metabolites],
         "lb" => Vector(lbs),


### PR DESCRIPTION
If there's complexity in data (stuff may be missing), it must be removed as
soon as possible in the process so that the core program logic may be stupid
and robust. I'm "removing" this complexity by using `maybemap` right at the
data parts that are missing, so that's perfectly obvious where the uncertainity
is (and, eventually, that we should aim for a nicer world where less nullable
fields in models are necessary... ;D).
