### PR TITLE
Add references to analysis functions

### DIFF
--- a/src/analysis/flux_balance_analysis.jl
+++ b/src/analysis/flux_balance_analysis.jl
@@ -42,6 +42,9 @@ max cᵀx
 s.t. S x = b
      xₗ ≤ x ≤ xᵤ
 ```
+See "Orth, J., Thiele, I. & Palsson, B. What is flux balance analysis?. Nat
+Biotechnol 28, 245–248 (2010). https://doi.org/10.1038/nbt.1614" for more
+information.
 
 The `optimizer` must be set to a `JuMP`-compatible optimizer, such as
 `GLPK.Optimizer` or `Tulip.Optimizer`

--- a/src/analysis/flux_variability_analysis.jl
+++ b/src/analysis/flux_variability_analysis.jl
@@ -19,7 +19,9 @@ s.t. S x = b
      cᵀx ≤ bounds(Z₀)[2]
 ```
 where Z₀:= cᵀx₀ is the objective value of an optimal solution of the associated
-FBA problem (see [`flux_balance_analysis`](@ref)).
+FBA problem (see [`flux_balance_analysis`](@ref)). See "Gudmundsson, S., Thiele,
+I. Computationally efficient flux variability analysis. BMC Bioinformatics 11,
+489 (2010). https://doi.org/10.1186/1471-2105-11-489" for more information.
 
 The `bounds` is a user-supplied function that specifies the objective bounds
 for the variability optimizations, by default it restricts the flux objective

--- a/src/analysis/parsimonious_flux_balance_analysis.jl
+++ b/src/analysis/parsimonious_flux_balance_analysis.jl
@@ -7,7 +7,28 @@
         relax_bounds=[1.0, 0.999999, 0.99999, 0.9999, 0.999, 0.99],
     )
 
-Run parsimonious flux balance analysis (pFBA) on the `model`.
+Run parsimonious flux balance analysis (pFBA) on the `model`. In short, pFBA
+runs two consecutive optimization problems. The first is traditional FBA:
+```
+max cᵀx = μ
+s.t. S x = b
+     xₗ ≤ x ≤ xᵤ
+```
+And the second is a quadratic optimization problem:
+```
+min Σᵢ xᵢ²
+s.t. S x = b
+     xₗ ≤ x ≤ xᵤ
+     μ = μ⁰
+```
+Where the optimal solution of the FBA problem, μ⁰, has been added as an
+additional constraint. See "Lewis, Nathan E, Hixson, Kim K, Conrad, Tom M,
+Lerman, Joshua A, Charusanti, Pep, Polpitiya, Ashoka D, Adkins, Joshua N,
+Schramm, Gunnar, Purvine, Samuel O, Lopez‐Ferrer, Daniel, Weitz, Karl K, Eils,
+Roland, König, Rainer, Smith, Richard D, Palsson, Bernhard Ø, (2010) Omic data
+from evolved E. coli are consistent with computed optimal growth from
+genome‐scale models. Molecular Systems Biology, 6. 390. doi:
+accession:10.1038/msb.2010.47" for more details.
 
 pFBA gets the model optimum by standard FBA (using
 [`flux_balance_analysis`](@ref) with `optimizer` and `modifications`), then

--- a/src/analysis/sampling/hit_and_run.jl
+++ b/src/analysis/sampling/hit_and_run.jl
@@ -8,7 +8,10 @@
     )
 
 Perform a basic hit and run sampling for `N` iterations on a constrained JuMP
-model in `opt_model`.
+model in `opt_model`. See "Robert L. Smith Efficient Monte Carlo Procedures for
+Generating Points Uniformly Distributed over Bounded Regions. Operations
+Research 32 (6) 1296-1308 https://doi.org/10.1287/opre.32.6.1296" for more
+details.
 
 The process generates `samplesize` samples, and logs the sample state each
 `keepevery` iterations.


### PR DESCRIPTION
1. Expanded the documentation of pFBA a little bit.
2. Added references to the functions used by each analysis method. For the most part I used the primary references (or first paper to implement) it, except FBA where I used the classic "what is fba" paper.

This closes #76.