### PR TITLE
⚡ Add warm start capability to fva and pfba

### DIFF
--- a/src/analysis/flux_variability_analysis.jl
+++ b/src/analysis/flux_variability_analysis.jl
@@ -145,7 +145,8 @@ function _FVA_optimize_reaction(model, rid, ret)
     var = all_variables(model)[abs(rid)]
 
     @objective(model, sense, var)
-    if termination_status(model) != MOI.OPTIMIZE_NOT_CALLED && solver_name(model) in ["Gurobi", ]
+    if termination_status(model) != MOI.OPTIMIZE_NOT_CALLED &&
+       solver_name(model) in ["Gurobi"]
         set_start_value.(all_variables(model), value.(all_variables(model))) # warm start
     end
     optimize!(model)

--- a/src/analysis/flux_variability_analysis.jl
+++ b/src/analysis/flux_variability_analysis.jl
@@ -145,6 +145,9 @@ function _FVA_optimize_reaction(model, rid, ret)
     var = all_variables(model)[abs(rid)]
 
     @objective(model, sense, var)
+    if termination_status(model) != MOI.OPTIMIZE_NOT_CALLED && solver_name(model) in ["Gurobi", ]
+        set_start_value.(all_variables(model), value.(all_variables(model))) # warm start
+    end
     optimize!(model)
 
     if is_solved(model)

--- a/src/analysis/parsimonious_flux_balance_analysis.jl
+++ b/src/analysis/parsimonious_flux_balance_analysis.jl
@@ -55,10 +55,10 @@ function parsimonious_flux_balance_analysis(
     # add the minimization constraint for total flux
     v = opt_model[:x] # fluxes
 
-    if solver_name(opt_model) in ["Gurobi", ]
+    if solver_name(opt_model) in ["Gurobi"]
         set_start_value.(all_variables(opt_model), value.(all_variables(opt_model))) # warm start
     end
-    
+
     @objective(opt_model, Min, sum(dot(v, v)))
 
     for rb in relax_bounds

--- a/src/analysis/parsimonious_flux_balance_analysis.jl
+++ b/src/analysis/parsimonious_flux_balance_analysis.jl
@@ -54,6 +54,11 @@ function parsimonious_flux_balance_analysis(
 
     # add the minimization constraint for total flux
     v = opt_model[:x] # fluxes
+
+    if solver_name(opt_model) in ["Gurobi", ]
+        set_start_value.(all_variables(opt_model), value.(all_variables(opt_model))) # warm start
+    end
+    
     @objective(opt_model, Min, sum(dot(v, v)))
 
     for rb in relax_bounds


### PR DESCRIPTION
Warm starts are a well documented way to increase the efficiency of solving consecutive optimization problems. I have added warm start capabilities to FVA and pFBA (it doesn't make sense for FBA, unless we make a new function that calls many of them on a cluster?).

The only issue is that I do not know which solvers support this, except for Gurobi... The open source ones tend not to I think... 
