### PR TITLE
use a gray filter for all console text

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 
 [deps]
 Clp = "e2554f3b-3117-50c0-817c-e040a3ddf72d"
-Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/COBREXA.jl
+++ b/src/COBREXA.jl
@@ -17,7 +17,6 @@ using Statistics
 using Random
 using MacroTools # for DSL :)
 using OrderedCollections
-using Crayons
 using Dates
 
 import Base: findfirst, getindex, show

--- a/src/base/constants.jl
+++ b/src/base/constants.jl
@@ -50,7 +50,6 @@ const _constants = (
         "reactome.compound",
         "biocyc",
     ),
-    colors = (empty = :dark_gray, payload = :default, key = :cyan),
 )
 
 const MAX_SENSE = COBREXA.MOI.MAX_SENSE

--- a/src/io/show/Gene.jl
+++ b/src/io/show/Gene.jl
@@ -1,5 +1,5 @@
 function Base.show(io::IO, ::MIME"text/plain", g::Gene)
     for fname in fieldnames(Gene)
-        _print_with_colors(io, "Gene.$(string(fname)): ", getfield(g, fname))
+        _pretty_print_keyvals(io, "Gene.$(string(fname)): ", getfield(g, fname))
     end
 end

--- a/src/io/show/Metabolite.jl
+++ b/src/io/show/Metabolite.jl
@@ -2,9 +2,9 @@ function Base.show(io::IO, ::MIME"text/plain", m::Metabolite)
     for fname in fieldnames(Metabolite)
         if fname == :charge
             c = isnothing(getfield(m, fname)) ? nothing : string(getfield(m, fname))
-            _print_with_colors(io, "Metabolite.$(string(fname)): ", c)
+            _pretty_print_keyvals(io, "Metabolite.$(string(fname)): ", c)
         else
-            _print_with_colors(io, "Metabolite.$(string(fname)): ", getfield(m, fname))
+            _pretty_print_keyvals(io, "Metabolite.$(string(fname)): ", getfield(m, fname))
         end
     end
 end

--- a/src/io/show/Reaction.jl
+++ b/src/io/show/Reaction.jl
@@ -31,25 +31,25 @@ function Base.show(io::IO, ::MIME"text/plain", r::Reaction)
 
     for fname in fieldnames(Reaction)
         if fname == :metabolites
-            _print_with_colors(
+            _pretty_print_keyvals(
                 io,
                 "Reaction.$(string(fname)): ",
                 _pretty_substances(substrates) * arrow * _pretty_substances(products),
             )
         elseif fname == :grr
-            _print_with_colors(
+            _pretty_print_keyvals(
                 io,
                 "Reaction.$(string(fname)): ",
                 _maybemap(x -> _unparse_grr(String, x), r.grr),
             )
         elseif fname in (:lb, :ub, :objective_coefficient)
-            _print_with_colors(
+            _pretty_print_keyvals(
                 io,
                 "Reaction.$(string(fname)): ",
                 string(getfield(r, fname)),
             )
         else
-            _print_with_colors(io, "Reaction.$(string(fname)): ", getfield(r, fname))
+            _pretty_print_keyvals(io, "Reaction.$(string(fname)): ", getfield(r, fname))
         end
     end
 end

--- a/src/io/show/models.jl
+++ b/src/io/show/models.jl
@@ -2,12 +2,12 @@
 Pretty printing of everything metabolic-modelish.
 """
 function Base.show(io::IO, ::MIME"text/plain", m::MetabolicModel)
-    _print_with_colors(io, "", "Metabolic model of type $(typeof(m))")
+    _pretty_print_keyvals(io, "", "Metabolic model of type $(typeof(m))")
     if prod(size(stoichiometry(m))) < 5_000_000
-        println(io, Crayon(foreground = _constants.colors.payload), stoichiometry(m))
+        println(io, stoichiometry(m))
     else # too big to display nicely
-        println(io, Crayon(foreground = _constants.colors.payload), "S = [...]")
+        println(io, "S = [...]")
     end
-    _print_with_colors(io, "Number of reactions: ", string(n_reactions(m)))
-    _print_with_colors(io, "Number of metabolites: ", string(n_metabolites(m)))
+    _pretty_print_keyvals(io, "Number of reactions: ", string(n_reactions(m)))
+    _pretty_print_keyvals(io, "Number of metabolites: ", string(n_metabolites(m)))
 end

--- a/src/io/show/pretty_printing.jl
+++ b/src/io/show/pretty_printing.jl
@@ -1,89 +1,52 @@
 """
-    _print_with_colors(io, def::String, payload; kwargs...)
+    _pretty_print_keyvals(io, def::String, payload; kwargs...)
 
-Prints nicely colorized keys and values.
+Nicely prints keys and values.
 """
-_print_with_colors(io, def::String, payload; kwargs...) =
-    _print_with_colors(io, def, isnothing(payload) ? "---" : string(payload); kwargs...)
+_pretty_print_keyvals(io, def::String, payload; kwargs...) =
+    _pretty_print_keyvals(io, def, isnothing(payload) ? "---" : string(payload); kwargs...)
 
 """
-    _print_with_colors(
+    _pretty_print_keyvals(
         io,
         def::String,
-        payload::String;
-        def_color = _constants.colors.key,
-        empty_color = _constants.colors.empty,
-        payload_color = _constants.colors.payload,
+        payload::String
     )
 
-Specialization of `_print_with_colors` for plain strings.
+Specialization of `_pretty_print_keyvals` for plain strings.
 """
-function _print_with_colors(
-    io,
-    def::String,
-    payload::String;
-    def_color = _constants.colors.key,
-    empty_color = _constants.colors.empty,
-    payload_color = _constants.colors.payload,
-)
-    print(io, Crayon(foreground = def_color), def)
+function _pretty_print_keyvals(io, def::String, payload::String)
+    print(io, def)
     if isempty(payload)
-        println(io, Crayon(foreground = empty_color), "---")
+        println(io, "---")
     else
-        println(io, Crayon(foreground = payload_color), payload)
+        println(io, payload)
     end
 end
 
 """
-    _print_with_colors(
+    _pretty_print_keyvals(
         io,
         def::String,
-        payload::Dict;
-        def_color = _constants.colors.key,
-        empty_color = _constants.colors.empty,
-        payload_color = _constants.colors.payload,
+        payload::Dict
     )
 
-Specialization of `_print_with_colors` for dictionaries.
+Specialization of `_pretty_print_keyvals` for dictionaries.
 """
-function _print_with_colors(
-    io,
-    def::String,
-    payload::Dict;
-    def_color = _constants.colors.key,
-    empty_color = _constants.colors.empty,
-    payload_color = _constants.colors.payload,
-)
+function _pretty_print_keyvals(io, def::String, payload::Dict)
 
-    print(io, Crayon(foreground = def_color), def)
+    print(io, def)
     if isempty(payload)
-        println(io, Crayon(foreground = empty_color), "---")
+        println(io, "---")
     else
         println(io, "")
         for (k, v) in payload
             if length(v) > 2 && length(v[1]) < 20
-                println(
-                    io,
-                    Crayon(foreground = payload_color),
-                    "\t",
-                    k,
-                    ": ",
-                    v[1],
-                    ", ..., ",
-                    v[end],
-                )
+                println(io, "\t", k, ": ", v[1], ", ..., ", v[end])
             elseif length(v[1]) > 20 # basically for envipath annotations... or long notes
-                println(
-                    io,
-                    Crayon(foreground = payload_color),
-                    "\t",
-                    k,
-                    ": ",
-                    v[1][1:20],
-                    "...",
-                )
+                println(io, "\t", k, ": ", v[1][1:20], "...")
             else
-                println(io, Crayon(foreground = payload_color), "\t", k, ": ", v)
+                println(io, "\t", k, ": ", v)
             end
         end
     end


### PR DESCRIPTION
color rendering from `Crayon` currently breaks rendering of notebooks. This needs to be eventually fixed and reverted.