### PR TITLE
Clean up tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Clp = "0.8"
 DistributedData = "0.1.3"
 Documenter = "0.26"
 JSON = "0.21"
@@ -36,7 +35,6 @@ Tulip = "0.7"
 julia = "1"
 
 [extras]
-Clp = "e2554f3b-3117-50c0-817c-e040a3ddf72d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
@@ -46,4 +44,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tulip = "6dd1b50a-3aae-11e9-10b5-ef983d2400fa"
 
 [targets]
-test = ["Clp", "Downloads", "OSQP", "SHA", "Test", "Tulip"]
+test = ["Downloads", "OSQP", "SHA", "Test", "Tulip"]

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Clp = "0.8"
 DistributedData = "0.1.3"
 Documenter = "0.26"
-GLPK = "0.14"
 JSON = "0.21"
 JuMP = "0.21"
 Literate = "2.8"
@@ -40,7 +39,6 @@ julia = "1"
 Clp = "e2554f3b-3117-50c0-817c-e040a3ddf72d"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 OSQP = "ab2f91bb-94b4-55e3-9ba0-7f65df51de79"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -48,4 +46,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tulip = "6dd1b50a-3aae-11e9-10b5-ef983d2400fa"
 
 [targets]
-test = ["Clp", "Downloads", "GLPK", "OSQP", "SHA", "Test", "Tulip"]
+test = ["Clp", "Downloads", "OSQP", "SHA", "Test", "Tulip"]

--- a/test/analysis/flux_balance_analysis.jl
+++ b/test/analysis/flux_balance_analysis.jl
@@ -5,11 +5,6 @@
     sol = JuMP.value.(lp[:x])
     @test sol ≈ [1.0, 2.0]
 
-    lp = flux_balance_analysis(cp, Clp.Optimizer)
-    @test termination_status(lp) === MOI.OPTIMAL
-    sol = JuMP.value.(lp[:x])
-    @test sol ≈ [1.0, 2.0]
-
     # test the maximization of the objective
     cp = test_simpleLP2()
     lp = flux_balance_analysis(cp, Tulip.Optimizer)

--- a/test/analysis/flux_balance_analysis.jl
+++ b/test/analysis/flux_balance_analysis.jl
@@ -1,6 +1,6 @@
 @testset "Flux balance analysis with CoreModel" begin
     cp = test_simpleLP()
-    lp = flux_balance_analysis(cp, GLPK.Optimizer)
+    lp = flux_balance_analysis(cp, Tulip.Optimizer)
     @test termination_status(lp) === MOI.OPTIMAL
     sol = JuMP.value.(lp[:x])
     @test sol ≈ [1.0, 2.0]
@@ -12,7 +12,7 @@
 
     # test the maximization of the objective
     cp = test_simpleLP2()
-    lp = flux_balance_analysis(cp, GLPK.Optimizer)
+    lp = flux_balance_analysis(cp, Tulip.Optimizer)
     @test termination_status(lp) === MOI.OPTIMAL
     sol = JuMP.value.(lp[:x])
     @test sol ≈ [-1.0, 2.0]
@@ -27,16 +27,16 @@
     cp = load_model(CoreModel, model_path)
     expected_optimum = 0.9219480950504393
 
-    lp = flux_balance_analysis(cp, GLPK.Optimizer)
+    lp = flux_balance_analysis(cp, Tulip.Optimizer)
     @test termination_status(lp) === MOI.OPTIMAL
     sol = JuMP.value.(lp[:x])
     @test objective_value(lp) ≈ expected_optimum
     @test cp.c' * sol ≈ expected_optimum
 
     # test the "nicer output" variants
-    fluxes_vec = flux_balance_analysis_vec(cp, GLPK.Optimizer)
+    fluxes_vec = flux_balance_analysis_vec(cp, Tulip.Optimizer)
     @test all(fluxes_vec .== sol)
-    fluxes_dict = flux_balance_analysis_dict(cp, GLPK.Optimizer)
+    fluxes_dict = flux_balance_analysis_dict(cp, Tulip.Optimizer)
     rxns = reactions(cp)
     @test all([fluxes_dict[rxns[i]] == sol[i] for i in eachindex(rxns)])
 end

--- a/test/analysis/flux_variability_analysis.jl
+++ b/test/analysis/flux_variability_analysis.jl
@@ -12,7 +12,7 @@
     fluxes = flux_variability_analysis(cp, [2], optimizer)
 
     @test size(fluxes) == (1, 2)
-    @test isapprox(fluxes, [2 2], atol=TEST_TOLERANCE)
+    @test isapprox(fluxes, [2 2], atol = TEST_TOLERANCE)
 
     # a special testcase for slightly sub-optimal FVA (gamma<1)
     cp = CoreModel(
@@ -25,23 +25,35 @@
         ["m1"],
     )
     fluxes = flux_variability_analysis(cp, optimizer)
-    @test isapprox(fluxes, [
-        1.0 1.0
-        0.0 0.0
-        -1.0 -1.0
-    ], atol=TEST_TOLERANCE)
+    @test isapprox(
+        fluxes,
+        [
+            1.0 1.0
+            0.0 0.0
+            -1.0 -1.0
+        ],
+        atol = TEST_TOLERANCE,
+    )
     fluxes = flux_variability_analysis(cp, optimizer; bounds = gamma_bounds(0.5))
-    @test isapprox(fluxes, [
-        0.5 1.0
-        0.0 0.5
-        -1.0 -0.5
-    ], atol=TEST_TOLERANCE)
+    @test isapprox(
+        fluxes,
+        [
+            0.5 1.0
+            0.0 0.5
+            -1.0 -0.5
+        ],
+        atol = TEST_TOLERANCE,
+    )
     fluxes = flux_variability_analysis(cp, optimizer; bounds = _ -> (0, Inf))
-    @test isapprox(fluxes, [
-        0.0 1.0
-        0.0 1.0
-        -1.0 0.0
-    ], atol=TEST_TOLERANCE)
+    @test isapprox(
+        fluxes,
+        [
+            0.0 1.0
+            0.0 1.0
+            -1.0 0.0
+        ],
+        atol = TEST_TOLERANCE,
+    )
 
     @test isempty(flux_variability_analysis(cp, Vector{Int}(), Tulip.Optimizer))
     @test_throws DomainError flux_variability_analysis(cp, [-1], Tulip.Optimizer)
@@ -52,10 +64,14 @@ end
     cp = test_simpleLP()
 
     fluxes = flux_variability_analysis(cp, [1, 2], Tulip.Optimizer; workers = W)
-    @test isapprox(fluxes, [
-        1.0 1.0
-        2.0 2.0
-    ], atol = TEST_TOLERANCE)
+    @test isapprox(
+        fluxes,
+        [
+            1.0 1.0
+            2.0 2.0
+        ],
+        atol = TEST_TOLERANCE,
+    )
 end
 
 @testset "Flux variability analysis with StandardModel" begin

--- a/test/analysis/flux_variability_analysis.jl
+++ b/test/analysis/flux_variability_analysis.jl
@@ -1,6 +1,6 @@
 @testset "Flux variability analysis" begin
     cp = test_simpleLP()
-    optimizer = GLPK.Optimizer
+    optimizer = Tulip.Optimizer
     fluxes = flux_variability_analysis(cp, optimizer)
 
     @test size(fluxes) == (2, 2)
@@ -12,7 +12,7 @@
     fluxes = flux_variability_analysis(cp, [2], optimizer)
 
     @test size(fluxes) == (1, 2)
-    @test fluxes == Matrix{Float64}([2 2])
+    @test isapprox(fluxes, [2 2], atol=TEST_TOLERANCE)
 
     # a special testcase for slightly sub-optimal FVA (gamma<1)
     cp = CoreModel(
@@ -25,39 +25,38 @@
         ["m1"],
     )
     fluxes = flux_variability_analysis(cp, optimizer)
-    @test fluxes ≈ [
+    @test isapprox(fluxes, [
         1.0 1.0
         0.0 0.0
         -1.0 -1.0
-    ]
+    ], atol=TEST_TOLERANCE)
     fluxes = flux_variability_analysis(cp, optimizer; bounds = gamma_bounds(0.5))
-    @test fluxes ≈ [
+    @test isapprox(fluxes, [
         0.5 1.0
         0.0 0.5
         -1.0 -0.5
-    ]
+    ], atol=TEST_TOLERANCE)
     fluxes = flux_variability_analysis(cp, optimizer; bounds = _ -> (0, Inf))
-    @test fluxes ≈ [
+    @test isapprox(fluxes, [
         0.0 1.0
         0.0 1.0
         -1.0 0.0
-    ]
+    ], atol=TEST_TOLERANCE)
 
-    @test isempty(flux_variability_analysis(cp, Vector{Int}(), GLPK.Optimizer))
-    @test_throws DomainError flux_variability_analysis(cp, [-1], GLPK.Optimizer)
-    @test_throws DomainError flux_variability_analysis(cp, [99999999], GLPK.Optimizer)
+    @test isempty(flux_variability_analysis(cp, Vector{Int}(), Tulip.Optimizer))
+    @test_throws DomainError flux_variability_analysis(cp, [-1], Tulip.Optimizer)
+    @test_throws DomainError flux_variability_analysis(cp, [99999999], Tulip.Optimizer)
 end
 
 @testset "Parallel FVA" begin
     cp = test_simpleLP()
     pids = addprocs(2, topology = :master_worker)
-    @everywhere using COBREXA, GLPK
-    fluxes = flux_variability_analysis(cp, [1, 2], GLPK.Optimizer; workers = pids)
-    @test fluxes ≈ [
+    @everywhere using COBREXA, Tulip
+    fluxes = flux_variability_analysis(cp, [1, 2], Tulip.Optimizer; workers = pids)
+    @test isapprox(fluxes, [
         1.0 1.0
         2.0 2.0
-    ]
-    rmprocs(pids)
+    ], atol = TEST_TOLERANCE)
 end
 
 @testset "Flux variability analysis with StandardModel" begin

--- a/test/analysis/flux_variability_analysis.jl
+++ b/test/analysis/flux_variability_analysis.jl
@@ -50,9 +50,8 @@ end
 
 @testset "Parallel FVA" begin
     cp = test_simpleLP()
-    pids = addprocs(2, topology = :master_worker)
-    @everywhere using COBREXA, Tulip
-    fluxes = flux_variability_analysis(cp, [1, 2], Tulip.Optimizer; workers = pids)
+
+    fluxes = flux_variability_analysis(cp, [1, 2], Tulip.Optimizer; workers = W)
     @test isapprox(fluxes, [
         1.0 1.0
         2.0 2.0

--- a/test/analysis/screening.jl
+++ b/test/analysis/screening.jl
@@ -34,22 +34,16 @@
         return mm
     end
 
-    ws = addprocs(2)
-    @everywhere using COBREXA
-    @everywhere using Tulip
-
     @test screen_variants(
         m,
         [[quad_rxn(i)] for i = 1:3],
         m -> flux_balance_analysis_vec(m, Tulip.Optimizer);
-        workers = ws,
+        workers = W,
     ) == [
         [250.0, -250.0, -1000.0, 250.0, 1000.0, 250.0, 250.0],
         [500.0, 500.0, 1000.0, 500.0, -1000.0, 500.0, 500.0],
         [500.0, 500.0, 1000.0, -500.0, 1000.0, 500.0, 500.0],
     ]
-
-    rmprocs(ws)
 
     # test solver modifications
     @test screen(

--- a/test/base/solver.jl
+++ b/test/base/solver.jl
@@ -1,7 +1,7 @@
 
 @testset "Solve LP" begin
     cp = test_simpleLP()
-    optimizer = GLPK.Optimizer
+    optimizer = Tulip.Optimizer
     lp = optimize_model(cp, optimizer)
     @test termination_status(lp) === MOI.OPTIMAL
     sol = JuMP.value.(lp[:x])

--- a/test/base/solver.jl
+++ b/test/base/solver.jl
@@ -1,14 +1,7 @@
 
 @testset "Solve LP" begin
     cp = test_simpleLP()
-    optimizer = Tulip.Optimizer
-    lp = optimize_model(cp, optimizer)
-    @test termination_status(lp) === MOI.OPTIMAL
-    sol = JuMP.value.(lp[:x])
-    @test sol ≈ [1.0, 2.0]
-
-    optimizer = Clp.Optimizer
-    lp = optimize_model(cp, optimizer)
+    lp = optimize_model(cp, Tulip.Optimizer)
     @test termination_status(lp) === MOI.OPTIMAL
     sol = JuMP.value.(lp[:x])
     @test sol ≈ [1.0, 2.0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,9 +49,13 @@ function download_data_file(url, path, hash)
     return path
 end
 
+# set up the workers for Distributed, so that the tests that require more
+# workers do not unnecessarily load the stuff multiple times
+W = addprocs(2)
+@everywhere using COBREXA, Tulip
+
 # load the test models
 run_test_file("data", "test_models.jl")
-
 
 # import base files
 @testset "COBREXA test suite" begin
@@ -65,3 +69,5 @@ run_test_file("data", "test_models.jl")
     run_test_dir("analysis")
     run_test_dir(joinpath("analysis", "sampling"), "Sampling")
 end
+
+rmprocs(W)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,6 @@ using COBREXA, Test
 using Clp
 using Distributed
 using Downloads
-using GLPK
 using JSON
 using JuMP
 using LinearAlgebra

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using COBREXA, Test
 
-using Clp
 using Distributed
 using Downloads
 using JSON


### PR DESCRIPTION
- replace GLPK by Tulip
- remove Clp
- prepare the `Distributed` workers in advance (saves time if more distributed stuff is tested, which is the case now)