### PR TITLE
re-add missing directories in ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 #ignore data files
 test/downloaded/
 test/tmpfiles/
-
+test/data
 .DS_Store
 
 # ignore VScode clutter
@@ -13,6 +13,10 @@ test/tmpfiles/
 docs/build/
 docs/site/
 
+# ignore file types
+*.mat
+*.xml
+*.json
 *.jl.*.cov
 .*.swp
 


### PR DESCRIPTION
I think this should not be left out ... it is fine for a new installation, but not if the directories already exist