### PR TITLE
🚚 Rename `add!` and `rm!` functions for `StandardModel`

### DIFF
--- a/docs/src/notebooks/5_basic_stdmodel_construction.jl
+++ b/docs/src/notebooks/5_basic_stdmodel_construction.jl
@@ -27,14 +27,14 @@ gene_list = [Gene(string("g", num)) for num = 1:8]
 #md #       `reactions`. However, these names conflict with generic accessors
 #md #       functions and will create problems downstream.
 
-add!(model, gene_list)
+add_genes!(model, gene_list)
 
 # ### Add metabolites to the model
 metabolite_list = [Metabolite(string("m", num)) for num = 1:4]
 
 metabolite_list[1].formula = "C6H12O6" # can edit metabolites, etc. directly
 
-add!(model, metabolite_list)
+add_metabolites!(model, metabolite_list)
 
 # ### Add reactions to the model
 
@@ -47,7 +47,7 @@ r1.grr = [["g1", "g2"], ["g3"]] # add some gene reaction rules
 r2 = Reaction("r2", Dict("m2" => -1.0, "m1" => 1.0), :backward)
 r3 = Reaction("r3", Dict("m2" => -1.0, "m3" => 1.0), :bidirectional)
 
-add!(model, [r1, r2, r3, r_m1]) # function approach
+add_reactions!(model, [r1, r2, r3, r_m1]) # function approach
 
 m1 = metabolite_list[1]
 m2 = metabolite_list[2]
@@ -83,7 +83,7 @@ model
 # ## Modifying existing models
 
 # It is also possible to modify a model by deleting certain genes.
-# This is simply achieved by calling `rm!`.
+# This is simply achieved by calling `remove_genes!`.
 
-rm!(Gene, model, ["g1", "g2"]; knockout_reactions = false)
+remove_genes!(model, ["g1", "g2"]; knockout_reactions = false)
 model

--- a/src/reconstruction/StandardModel.jl
+++ b/src/reconstruction/StandardModel.jl
@@ -5,18 +5,11 @@ Add `rxns` to `model` based on reaction `id`.
 """
 function add_reactions!(model::StandardModel, rxns::Vector{Reaction})
     for rxn in rxns
-        add_reaction!(model, rxn)
+        model.reactions[rxn.id] = rxn
     end
 end
 
-"""
-    add_reaction(model::StandardModel, rxn::Reaction)
-
-Add `rxn` to `model` based on reaction `id`.
-"""
-function add_reaction!(model::StandardModel, rxn::Reaction)
-    model.reactions[rxn.id] = rxn
-end
+add_reactions!(model::StandardModel, rxn::Reaction) = add_reactions!(model, [rxn])
 
 """
     add_metabolites!(model::StandardModel, mets::Vector{Metabolite})
@@ -25,19 +18,12 @@ Add `mets` to `model` based on metabolite `id`.
 """
 function add_metabolites!(model::StandardModel, mets::Vector{Metabolite})
     for met in mets
-        add_metabolite!(model, met)
+        model.metabolites[met.id] = met
     end
 end
 
-"""
-    add_metabolite!(model::StandardModel, met::Metabolite)
-
-Add `mets` to `model` based on metabolite `id`.
-"""
-function add_metabolite!(model::StandardModel, met::Metabolite)
-    model.metabolites[met.id] = met
-end
-
+add_metabolites!(model::StandardModel, met::Metabolite) =  add_metabolite!(model, [met])
+    
 """
     add_genes!(model::StandardModel, genes::Vector{Gene})
 
@@ -45,18 +31,11 @@ Add `genes` to `model` based on gene `id`.
 """
 function add_genes!(model::StandardModel, genes::Vector{Gene})
     for gene in genes
-        add_gene!(model, gene)
+        model.genes[gene.id] = gene
     end
 end
 
-"""
-    add_gene!(model::StandardModel, gene::Gene)
-
-Add `gene` to `model` based on gene `id`.
-"""
-function add_gene!(model::StandardModel, gene::Gene)
-    model.genes[gene.id] = gene
-end
+add_genes!(model::StandardModel, gene::Gene) = add_genes!(model, [gene]) 
 
 """
     @add_reactions!(model::Symbol, ex::Expr)
@@ -108,27 +87,34 @@ macro add_reactions!(model::Symbol, ex::Expr)
             push!(all_reactions.args, :(r.lb = $lb))
             push!(all_reactions.args, :(r.ub = $ub))
         end
-        push!(all_reactions.args, :(add!($model, r)))
+        push!(all_reactions.args, :(add_reactions!($model, r)))
     end
     return all_reactions
 end
 
 """
-    rm!(::Type{Reaction}, model::StandardModel, ids::Vector{String})
+    remove_reactions!(model::StandardModel, ids::Vector{String})
 
 Remove all reactions with `ids` from `model`.
 
 # Example
-rm!(Reaction, model, ["EX_glc__D_e", "fba"])
-rm!(Reaction, model, "EX_glc__D_e")
+remove_reactions!(model, ["EX_glc__D_e", "fba"])
 """
-function rm!(::Type{Reaction}, model::StandardModel, ids::Vector{String})
+function remove_reactions!(model::StandardModel, ids::Vector{String})
     for id in ids
         rm!(Reaction, model, id)
     end
 end
 
-function rm!(::Type{Reaction}, model::StandardModel, id::String)
+"""
+    remove_reaction!(model::StandardModel, id::String)
+
+Remove reaction with `id` from `model`.
+
+# Example
+remove_reaction!(model, "EX_glc__D_e")
+"""
+function remove_reaction!(model::StandardModel, id::String)
     rxn = pop!(model.reactions, id)
 end
 

--- a/src/reconstruction/StandardModel.jl
+++ b/src/reconstruction/StandardModel.jl
@@ -152,7 +152,7 @@ function remove_genes!(
         rm_reactions = String[]
         for (rid, r) in model.reactions
             if !isnothing(r.grr) &&
-               all([any(in.(gids, Ref(conjunction))) for conjunction in r.grr])
+               all(any(in.(gids, Ref(conjunction))) for conjunction in r.grr)
                 push!(rm_reactions, rid)
             end
         end

--- a/src/reconstruction/StandardModel.jl
+++ b/src/reconstruction/StandardModel.jl
@@ -9,7 +9,12 @@ function add_reactions!(model::StandardModel, rxns::Vector{Reaction})
     end
 end
 
-add_reactions!(model::StandardModel, rxn::Reaction) = add_reactions!(model, [rxn])
+"""
+    add_reaction!(model::StandardModel, rxn::Reaction)
+
+Add `rxn` to `model` based on reaction `id`.
+"""
+add_reaction!(model::StandardModel, rxn::Reaction) = add_reactions!(model, [rxn])
 
 """
     add_metabolites!(model::StandardModel, mets::Vector{Metabolite})
@@ -22,7 +27,12 @@ function add_metabolites!(model::StandardModel, mets::Vector{Metabolite})
     end
 end
 
-add_metabolites!(model::StandardModel, met::Metabolite) =  add_metabolites!(model, [met])
+"""
+    add_metabolite!(model::StandardModel, met::Metabolite)
+
+Add `met` to `model` based on metabolite `id`.
+"""
+add_metabolite!(model::StandardModel, met::Metabolite) =  add_metabolites!(model, [met])
     
 """
     add_genes!(model::StandardModel, genes::Vector{Gene})
@@ -35,7 +45,12 @@ function add_genes!(model::StandardModel, genes::Vector{Gene})
     end
 end
 
-add_genes!(model::StandardModel, gene::Gene) = add_genes!(model, [gene]) 
+"""
+    add_gene!(model::StandardModel, genes::Gene)
+
+Add `gene` to `model` based on gene `id`.
+"""
+add_gene!(model::StandardModel, gene::Gene) = add_genes!(model, [gene]) 
 
 """
     @add_reactions!(model::Symbol, ex::Expr)
@@ -86,7 +101,7 @@ macro add_reactions!(model::Symbol, ex::Expr)
             push!(all_reactions.args, :(r.lb = $lb))
             push!(all_reactions.args, :(r.ub = $ub))
         end
-        push!(all_reactions.args, :(add_reactions!($model, r)))
+        push!(all_reactions.args, :(add_reaction!($model, r)))
     end
     return all_reactions
 end
@@ -99,14 +114,23 @@ Remove all reactions with `ids` from `model`. Note, may result in orphan metabol
 # Example
 ```
 remove_reactions!(model, ["EX_glc__D_e", "fba"])
-remove_reaction!(model, "EX_glc__D_e")
 ```
 """
 function remove_reactions!(model::StandardModel, ids::Vector{String})
     pop!.(Ref(model.reactions), ids)
 end
 
-remove_reactions!(model::StandardModel, id::String) = remove_reactions!(model, [id]) 
+"""
+    remove_reaction!(model::StandardModel, id::String)
+
+Remove reaction with `id` from `model`. Note, may result in orphan metabolites.
+
+# Example
+```
+remove_reaction!(model, "EX_glc__D_e")
+```
+"""
+remove_reaction!(model::StandardModel, id::String) = remove_reactions!(model, [id]) 
 
 """
     remove_metabolites!(model::StandardModel, ids::Vector{String})
@@ -118,14 +142,25 @@ require the deleted metabolite, in which case analysis functions will error.
 # Example
 ```
 remove_metabolites!(model, ["atp_c", "adp_c"])
-remove_metabolites!(model, "atp_c")
 ```
 """
 function remove_metabolites!(model::StandardModel, ids::Vector{String})
     pop!.(Ref(model.metabolites), ids)    
 end
 
-remove_metabolites!(model::StandardModel, id::String) = remove_metabolites!(model, [id]) 
+"""
+    remove_metabolite!(model::StandardModel, id::String)
+
+Remove metabolite with `id` from `model`.
+Warning, this could leave the model inconsistent, e.g. a reaction might
+require the deleted metabolite, in which case analysis functions will error.
+
+# Example
+```
+remove_metabolite!(model, "atp_c")
+```
+"""
+remove_metabolite!(model::StandardModel, id::String) = remove_metabolites!(model, [id]) 
 
 """
     remove_genes!(
@@ -139,8 +174,7 @@ constrain reactions that require the genes to function to carry zero flux.
 
 # Example
 ```
-rm!(model, ["g1", "g2"])
-rm!(model, "g1")
+remove_genes!(model, ["g1", "g2"])
 ```
 """
 function remove_genes!(
@@ -161,7 +195,22 @@ function remove_genes!(
     pop!.(Ref(model.genes), gids)
 end
 
-remove_genes!(model::StandardModel, gid::String; knockout_reactions::Bool = false) = remove_genes!(model, [gid]; knockout_reactions = knockout_reactions)
+"""
+    remove_gene!(
+        model::StandardModel,
+        id::Vector{String};
+        knockout_reactions::Bool = false,
+    )
+
+Remove gene with `id` from `model`. If `knockout_reactions` is true, then also 
+constrain reactions that require the genes to function to carry zero flux.
+
+# Example
+```
+remove_gene!(model, "g1")
+```
+"""
+remove_gene!(model::StandardModel, gid::String; knockout_reactions::Bool = false) = remove_genes!(model, [gid]; knockout_reactions = knockout_reactions)
 
 function set_bound(model::StandardModel, reaction_id::String; ub, lb)
     reaction = model.reactions[reaction_id]

--- a/src/reconstruction/StandardModel.jl
+++ b/src/reconstruction/StandardModel.jl
@@ -1,45 +1,60 @@
 """
-    add!(model::StandardModel, rxns::Union{Vector{Reaction}, Reaction})
+    add_reactions!(model::StandardModel, rxns::Vector{Reaction})
 
-Add `rxn(s)` to `model` if they are not already present based on reaction `id`.
+Add `rxns` to `model` based on reaction `id`.
 """
-function add!(model::StandardModel, rxns::Vector{Reaction})
+function add_reactions!(model::StandardModel, rxns::Vector{Reaction})
     for rxn in rxns
-        add!(model, rxn)
+        add_reaction!(model, rxn)
     end
 end
 
-function add!(model::StandardModel, rxn::Reaction)
+"""
+    add_reaction(model::StandardModel, rxn::Reaction)
+
+Add `rxn` to `model` based on reaction `id`.
+"""
+function add_reaction!(model::StandardModel, rxn::Reaction)
     model.reactions[rxn.id] = rxn
 end
 
 """
-    add!(model::StandardModel, mets::Union{Vector{Metabolite}, Metabolite})
+    add_metabolites!(model::StandardModel, mets::Vector{Metabolite})
 
-Add `met(s)` to `model` if they are not already present, based on metabolite `id`.
+Add `mets` to `model` based on metabolite `id`.
 """
-function add!(model::StandardModel, mets::Vector{Metabolite})
+function add_metabolites!(model::StandardModel, mets::Vector{Metabolite})
     for met in mets
-        add!(model, met)
+        add_metabolite!(model, met)
     end
 end
 
-function add!(model::StandardModel, met::Metabolite)
+"""
+    add_metabolite!(model::StandardModel, met::Metabolite)
+
+Add `mets` to `model` based on metabolite `id`.
+"""
+function add_metabolite!(model::StandardModel, met::Metabolite)
     model.metabolites[met.id] = met
 end
 
 """
-    add!(model::StandardModel, genes::Union{Vector{Gene}, Gene})
+    add_genes!(model::StandardModel, genes::Vector{Gene})
 
-Add `gene(s)` to `model` if they are not already present based on gene `id`.
+Add `genes` to `model` based on gene `id`.
 """
-function add!(model::StandardModel, genes::Vector{Gene})
+function add_genes!(model::StandardModel, genes::Vector{Gene})
     for gene in genes
-        add!(model, gene)
+        add_gene!(model, gene)
     end
 end
 
-function add!(model::StandardModel, gene::Gene)
+"""
+    add_gene!(model::StandardModel, gene::Gene)
+
+Add `gene` to `model` based on gene `id`.
+"""
+function add_gene!(model::StandardModel, gene::Gene)
     model.genes[gene.id] = gene
 end
 

--- a/test/analysis/knockouts.jl
+++ b/test/analysis/knockouts.jl
@@ -1,20 +1,20 @@
 @testset "single_knockout" begin
     m = StandardModel()
-    add_metabolites!(m, Metabolite("A"))
-    add_metabolites!(m, Metabolite("B"))
+    add_metabolite!(m, Metabolite("A"))
+    add_metabolite!(m, Metabolite("B"))
 
-    add_genes!(m, Gene("g1"))
-    add_genes!(m, Gene("g2"))
-    add_reactions!(m, Reaction("v1", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"]]))
-    add_reactions!(
+    add_gene!(m, Gene("g1"))
+    add_gene!(m, Gene("g2"))
+    add_reaction!(m, Reaction("v1", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"]]))
+    add_reaction!(
         m,
         Reaction("v2", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1", "g2"]]),
     )
-    add_reactions!(
+    add_reaction!(
         m,
         Reaction("v3", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"], ["g2"]]),
     )
-    add_reactions!(
+    add_reaction!(
         m,
         Reaction(
             "v4",
@@ -45,16 +45,16 @@ end
 
 @testset "multiple_knockouts" begin
     m = StandardModel()
-    add_metabolites!(m, Metabolite("A"))
-    add_metabolites!(m, Metabolite("B"))
-    add_genes!(m, Gene("g1"))
-    add_genes!(m, Gene("g2"))
-    add_genes!(m, Gene("g3"))
-    add_reactions!(
+    add_metabolite!(m, Metabolite("A"))
+    add_metabolite!(m, Metabolite("B"))
+    add_gene!(m, Gene("g1"))
+    add_gene!(m, Gene("g2"))
+    add_gene!(m, Gene("g3"))
+    add_reaction!(
         m,
         Reaction("v1", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"], ["g3"]]),
     )
-    add_reactions!(
+    add_reaction!(
         m,
         Reaction(
             "v2",
@@ -62,7 +62,7 @@ end
             grr = [["g1", "g2"], ["g3"]],
         ),
     )
-    add_reactions!(
+    add_reaction!(
         m,
         Reaction(
             "v3",

--- a/test/analysis/knockouts.jl
+++ b/test/analysis/knockouts.jl
@@ -1,20 +1,20 @@
 @testset "single_knockout" begin
     m = StandardModel()
-    add!(m, Metabolite("A"))
-    add!(m, Metabolite("B"))
+    add_metabolites!(m, Metabolite("A"))
+    add_metabolites!(m, Metabolite("B"))
 
-    add!(m, Gene("g1"))
-    add!(m, Gene("g2"))
-    add!(m, Reaction("v1", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"]]))
-    add!(
+    add_genes!(m, Gene("g1"))
+    add_genes!(m, Gene("g2"))
+    add_reactions!(m, Reaction("v1", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"]]))
+    add_reactions!(
         m,
         Reaction("v2", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1", "g2"]]),
     )
-    add!(
+    add_reactions!(
         m,
         Reaction("v3", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"], ["g2"]]),
     )
-    add!(
+    add_reactions!(
         m,
         Reaction(
             "v4",
@@ -45,16 +45,16 @@ end
 
 @testset "multiple_knockouts" begin
     m = StandardModel()
-    add!(m, Metabolite("A"))
-    add!(m, Metabolite("B"))
-    add!(m, Gene("g1"))
-    add!(m, Gene("g2"))
-    add!(m, Gene("g3"))
-    add!(
+    add_metabolites!(m, Metabolite("A"))
+    add_metabolites!(m, Metabolite("B"))
+    add_genes!(m, Gene("g1"))
+    add_genes!(m, Gene("g2"))
+    add_genes!(m, Gene("g3"))
+    add_reactions!(
         m,
         Reaction("v1", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"], ["g3"]]),
     )
-    add!(
+    add_reactions!(
         m,
         Reaction(
             "v2",
@@ -62,7 +62,7 @@ end
             grr = [["g1", "g2"], ["g3"]],
         ),
     )
-    add!(
+    add_reactions!(
         m,
         Reaction(
             "v3",

--- a/test/reconstruction/StandardModel.jl
+++ b/test/reconstruction/StandardModel.jl
@@ -33,41 +33,41 @@
     model.genes = OrderedDict(g.id => g for g in genes)
 
     ### reactions
-    add!(model, [r3, r4])
+    add_reactions!(model, [r3, r4])
     @test length(model.reactions) == 4
 
-    add!(model, r5)
+    add_reactions!(model, r5)
     @test length(model.reactions) == 5
 
-    rm!(Reaction, model, ["r5", "r4"])
+    remove_reactions!(model, ["r5", "r4"])
     @test length(model.reactions) == 3
 
-    rm!(Reaction, model, "r1")
+    remove_reactions!(model, "r1")
     @test length(model.reactions) == 2
 
     ### metabolites
-    add!(model, [m5, m6])
+    add_metabolites!(model, [m5, m6])
     @test length(model.metabolites) == 6
 
-    add!(model, m7)
+    add_metabolites!(model, m7)
     @test length(model.metabolites) == 7
 
-    rm!(Metabolite, model, ["m5", "m4"])
+    remove_metabolites!(model, ["m5", "m4"])
     @test length(model.metabolites) == 5
 
-    rm!(Metabolite, model, "m1")
+    remove_metabolites!(model, "m1")
     @test length(model.metabolites) == 4
 
     ### genes
-    add!(model, [g5, g6])
+    add_genes!(model, [g5, g6])
     @test length(model.genes) == 6
 
-    add!(model, g7)
+    add_genes!(model, g7)
     @test length(model.genes) == 7
 
-    rm!(Gene, model, ["g5", "g4"])
+    remove_genes!(model, ["g5", "g4"])
     @test length(model.genes) == 5
 
-    rm!(Gene, model, "g1")
+    remove_genes!(model, "g1")
     @test length(model.genes) == 4
 end

--- a/test/reconstruction/StandardModel.jl
+++ b/test/reconstruction/StandardModel.jl
@@ -36,38 +36,38 @@
     add_reactions!(model, [r3, r4])
     @test length(model.reactions) == 4
 
-    add_reactions!(model, r5)
+    add_reaction!(model, r5)
     @test length(model.reactions) == 5
 
     remove_reactions!(model, ["r5", "r4"])
     @test length(model.reactions) == 3
 
-    remove_reactions!(model, "r1")
+    remove_reaction!(model, "r1")
     @test length(model.reactions) == 2
 
     ### metabolites
     add_metabolites!(model, [m5, m6])
     @test length(model.metabolites) == 6
 
-    add_metabolites!(model, m7)
+    add_metabolite!(model, m7)
     @test length(model.metabolites) == 7
 
     remove_metabolites!(model, ["m5", "m4"])
     @test length(model.metabolites) == 5
 
-    remove_metabolites!(model, "m1")
+    remove_metabolite!(model, "m1")
     @test length(model.metabolites) == 4
 
     ### genes
     add_genes!(model, [g5, g6])
     @test length(model.genes) == 6
 
-    add_genes!(model, g7)
+    add_gene!(model, g7)
     @test length(model.genes) == 7
 
     remove_genes!(model, ["g5", "g4"])
     @test length(model.genes) == 5
 
-    remove_genes!(model, "g1")
+    remove_gene!(model, "g1")
     @test length(model.genes) == 4
 end

--- a/test/reconstruction/add_reactions.jl
+++ b/test/reconstruction/add_reactions.jl
@@ -3,9 +3,9 @@
     A = Metabolite("A")
     B = Metabolite("B")
     C = Metabolite("C")
-    add!(mod, A)
-    add!(mod, B)
-    add!(mod, C)
+    add_metabolites!(mod, A)
+    add_metabolites!(mod, B)
+    add_metabolites!(mod, C)
 
     @add_reactions! mod begin
         "v1", nothing ⟷ A

--- a/test/reconstruction/add_reactions.jl
+++ b/test/reconstruction/add_reactions.jl
@@ -3,10 +3,8 @@
     A = Metabolite("A")
     B = Metabolite("B")
     C = Metabolite("C")
-    add_metabolites!(mod, A)
-    add_metabolites!(mod, B)
-    add_metabolites!(mod, C)
-
+    add_metabolites!(mod, [A, B, C])
+    
     @add_reactions! mod begin
         "v1", nothing ⟷ A
         "v2", nothing ⟷ B, -500

--- a/test/reconstruction/knockouts.jl
+++ b/test/reconstruction/knockouts.jl
@@ -7,20 +7,20 @@ is available, but inside a group all of the genes need to be available
 
 @testset "knockout_single_gene" begin
     m = StandardModel()
-    add_metabolites!(m, Metabolite("A"))
-    add_metabolites!(m, Metabolite("B"))
-    add_genes!(m, Gene("g1"))
-    add_genes!(m, Gene("g2"))
-    add_reactions!(m, Reaction("v1", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"]]))
-    add_reactions!(
+    add_metabolite!(m, Metabolite("A"))
+    add_metabolite!(m, Metabolite("B"))
+    add_gene!(m, Gene("g1"))
+    add_gene!(m, Gene("g2"))
+    add_reaction!(m, Reaction("v1", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"]]))
+    add_reaction!(
         m,
         Reaction("v2", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1", "g2"]]),
     )
-    add_reactions!(
+    add_reaction!(
         m,
         Reaction("v3", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"], ["g2"]]),
     )
-    add_reactions!(
+    add_reaction!(
         m,
         Reaction(
             "v4",
@@ -29,7 +29,7 @@ is available, but inside a group all of the genes need to be available
         ),
     )
 
-    remove_genes!(m, "g1", knockout_reactions = true)
+    remove_gene!(m, "g1", knockout_reactions = true)
 
     @test length(m.reactions) == 2
     @test !haskey(m.reactions, "v1")
@@ -38,12 +38,12 @@ end
 
 @testset "knockout_multiple_genes" begin
     m = StandardModel()
-    add_metabolites!(m, Metabolite("A"))
-    add_metabolites!(m, Metabolite("B"))
-    add_genes!(m, Gene("g1"))
-    add_genes!(m, Gene("g2"))
-    add_genes!(m, Gene("g3"))
-    add_reactions!(
+    add_metabolite!(m, Metabolite("A"))
+    add_metabolite!(m, Metabolite("B"))
+    add_gene!(m, Gene("g1"))
+    add_gene!(m, Gene("g2"))
+    add_gene!(m, Gene("g3"))
+    add_reaction!(
         m,
         Reaction(
             "v1",
@@ -51,7 +51,7 @@ end
             grr = [["g1"], ["g2"], ["g3"]],
         ),
     )
-    add_reactions!(
+    add_reaction!(
         m,
         Reaction("v2", metabolites = Dict("A" => 1.0, "B" => -1.0), grr = [["g1"], ["g3"]]),
     )

--- a/test/reconstruction/knockouts.jl
+++ b/test/reconstruction/knockouts.jl
@@ -7,20 +7,20 @@ is available, but inside a group all of the genes need to be available
 
 @testset "knockout_single_gene" begin
     m = StandardModel()
-    add!(m, Metabolite("A"))
-    add!(m, Metabolite("B"))
-    add!(m, Gene("g1"))
-    add!(m, Gene("g2"))
-    add!(m, Reaction("v1", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"]]))
-    add!(
+    add_metabolites!(m, Metabolite("A"))
+    add_metabolites!(m, Metabolite("B"))
+    add_genes!(m, Gene("g1"))
+    add_genes!(m, Gene("g2"))
+    add_reactions!(m, Reaction("v1", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"]]))
+    add_reactions!(
         m,
         Reaction("v2", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1", "g2"]]),
     )
-    add!(
+    add_reactions!(
         m,
         Reaction("v3", metabolites = Dict("A" => -1.0, "B" => 1.0), grr = [["g1"], ["g2"]]),
     )
-    add!(
+    add_reactions!(
         m,
         Reaction(
             "v4",
@@ -29,7 +29,7 @@ is available, but inside a group all of the genes need to be available
         ),
     )
 
-    rm!(Gene, m, "g1", knockout_reactions = true)
+    remove_genes!(m, "g1", knockout_reactions = true)
 
     @test length(m.reactions) == 2
     @test !haskey(m.reactions, "v1")
@@ -38,12 +38,12 @@ end
 
 @testset "knockout_multiple_genes" begin
     m = StandardModel()
-    add!(m, Metabolite("A"))
-    add!(m, Metabolite("B"))
-    add!(m, Gene("g1"))
-    add!(m, Gene("g2"))
-    add!(m, Gene("g3"))
-    add!(
+    add_metabolites!(m, Metabolite("A"))
+    add_metabolites!(m, Metabolite("B"))
+    add_genes!(m, Gene("g1"))
+    add_genes!(m, Gene("g2"))
+    add_genes!(m, Gene("g3"))
+    add_reactions!(
         m,
         Reaction(
             "v1",
@@ -51,11 +51,12 @@ end
             grr = [["g1"], ["g2"], ["g3"]],
         ),
     )
-    add!(
+    add_reactions!(
         m,
         Reaction("v2", metabolites = Dict("A" => 1.0, "B" => -1.0), grr = [["g1"], ["g3"]]),
     )
-    rm!(Gene, m, ["g1", "g3"], knockout_reactions = true)
+
+    remove_genes!(m, ["g1", "g3"], knockout_reactions = true)
 
     @test haskey(m.reactions, "v1")
     @test !haskey(m.reactions, "v2")


### PR DESCRIPTION
Currently `CoreModel` uses e.g. `remove_reaction` and `add_reaction` etc. However, `StandardModel` uses `add!` and `rm!`, this adds too much variability - the same method names should apply. Here `StandardModel`'s functions are renamed. 

However, a slight issue remains that the functions are in place for `StandardModel`, hence they have the bang!, while for `CoreModel` they make a new model and are thus not in place. The user thus needs to remember to use the bang for `StandardModel`s and not for `CoreModel`s. This is slightly non-optimal... what do you think? 
