### PR TITLE
💄 Update pretty printing of models

### DIFF
--- a/src/base/constants.jl
+++ b/src/base/constants.jl
@@ -4,6 +4,7 @@ A named tuple that contains the magic values that are used globally for
 whatever purposes.
 """
 const _constants = (
+    default_stoich_show_size = 50_000,
     default_reaction_bound = 1e3,
     tolerance = 1e-6,
     sampling_keep_iters = 100,

--- a/src/io/show/MetabolicModel.jl
+++ b/src/io/show/MetabolicModel.jl
@@ -3,7 +3,7 @@ Pretty printing of everything metabolic-modelish.
 """
 function Base.show(io::IO, ::MIME"text/plain", m::MetabolicModel)
     _pretty_print_keyvals(io, "", "Metabolic model of type $(typeof(m))")
-    if prod(size(stoichiometry(m))) < 5_000_000
+    if n_reactions(m) <= _constants.default_stoich_show_size
         println(io, stoichiometry(m))
     else # too big to display nicely
         println(io, "S = [...]")


### PR DESCRIPTION
The previous bound for displaying the sparse matrix of a `stoichiometry` was too small. Here I made it a little bigger. But maybe we want to update/change more things wrt pretty printing? 