### PR TITLE
🩹 ✨ Atoms in reactions and overall flux

### DIFF
--- a/src/base/utils/StandardModel.jl
+++ b/src/base/utils/StandardModel.jl
@@ -68,6 +68,22 @@ function atom_exchange(flux_dict::Dict{String,Float64}, model::StandardModel)
 end
 
 """
+    atom_exchange(rxn_id::String, model::StandardModel)
+
+Return a dictionary mapping the flux of atoms through a reaction in `model`.
+"""
+function atom_exchange(rxn_id::String, model::StandardModel)
+    atom_flux = Dict{String,Float64}()
+    for (met, stoich_rxn) in model.reactions[rxn_id].metabolites
+        adict = get_atoms(model.metabolites[met])
+        for (atom, stoich_molecule) in adict
+            atom_flux[atom] = get(atom_flux, atom, 0.0) + stoich_rxn * stoich_molecule
+        end
+    end
+    return atom_flux
+end
+
+"""
     metabolite_fluxes(flux_dict::Dict{String, Float64}, model::StandardModel)
 
 Return two dictionaries of metabolite `id`s mapped to reactions that consume or 
@@ -75,7 +91,6 @@ produce them given the flux distribution supplied in `fluxdict`.
 """
 function metabolite_fluxes(flux_dict::Dict{String,Float64}, model::StandardModel)
     S = stoichiometry(model)
-    met_flux = Dict{String,Float64}()
     rxnids = reactions(model)
     metids = metabolites(model)
 

--- a/src/base/utils/StandardModel.jl
+++ b/src/base/utils/StandardModel.jl
@@ -56,10 +56,10 @@ function atom_exchange(flux_dict::Dict{String,Float64}, model::StandardModel)
     atom_flux = Dict{String,Float64}()
     for (rxn_id, flux) in flux_dict
         if is_boundary(model.reactions[rxn_id])
-            for (met, stoich) in model.reactions[rxn_id].metabolites
+            for (met, stoich_rxn) in model.reactions[rxn_id].metabolites
                 adict = get_atoms(model.metabolites[met])
-                for (atom, stoich) in adict
-                    atom_flux[atom] = get(atom_flux, atom, 0.0) + flux * stoich
+                for (atom, stoich_molecule) in adict
+                    atom_flux[atom] = get(atom_flux, atom, 0.0) + flux * stoich_rxn * stoich_molecule
                 end
             end
         end

--- a/test/base/utils/StandardModel.jl
+++ b/test/base/utils/StandardModel.jl
@@ -12,14 +12,14 @@
 
     # atom tracker
     atom_fluxes = atom_exchange(sol, model)
-    @test isapprox(atom_fluxes["C"], 37.1902, TEST_TOLERANCE)
+    @test isapprox(atom_fluxes["C"], 37.1902; atol=TEST_TOLERANCE)
     @test atom_exchange("FBA", model)["C"] == 0.0
-    @test isapprox(atom_exchange("BIOMASS_Ecoli_core_w_GAM", model)["C"], -42.5555, TEST_TOLERANCE)
+    @test isapprox(atom_exchange("BIOMASS_Ecoli_core_w_GAM", model)["C"], -42.5555; atol=TEST_TOLERANCE)
     
     # metabolite trackers
     consuming, producing = metabolite_fluxes(sol, model)
-    @test isapprox(consuming["atp_c"]["PFK"], -7.47738, TEST_TOLERANCE)
-    @test isapprox(producing["atp_c"]["PYK"], 1.75818, TEST_TOLERANCE)
+    @test isapprox(consuming["atp_c"]["PFK"], -7.47738; atol=TEST_TOLERANCE)
+    @test isapprox(producing["atp_c"]["PYK"], 1.75818; atol=TEST_TOLERANCE)
 
     # set bounds
     cbm = make_optimization_model(model, optimizer)

--- a/test/base/utils/StandardModel.jl
+++ b/test/base/utils/StandardModel.jl
@@ -1,4 +1,3 @@
-
 @testset "StandardModel utilities" begin
     model = load_model(StandardModel, model_paths["e_coli_core.json"])
 
@@ -13,12 +12,14 @@
 
     # atom tracker
     atom_fluxes = atom_exchange(sol, model)
-    @test isapprox(atom_fluxes["C"], -37.1902, atol = 1e-3)
-
+    @test isapprox(atom_fluxes["C"], 37.1902, TEST_TOLERANCE)
+    @test atom_exchange("FBA", model)["C"] == 0.0
+    @test isapprox(atom_exchange("BIOMASS_Ecoli_core_w_GAM", model)["C"], -42.5555, TEST_TOLERANCE)
+    
     # metabolite trackers
     consuming, producing = metabolite_fluxes(sol, model)
-    @test isapprox(consuming["atp_c"]["PFK"], -7.47738, atol = 1e-3)
-    @test isapprox(producing["atp_c"]["PYK"], 1.75818, atol = 1e-3)
+    @test isapprox(consuming["atp_c"]["PFK"], -7.47738, TEST_TOLERANCE)
+    @test isapprox(producing["atp_c"]["PYK"], 1.75818, TEST_TOLERANCE)
 
     # set bounds
     cbm = make_optimization_model(model, optimizer)

--- a/test/base/utils/StandardModel.jl
+++ b/test/base/utils/StandardModel.jl
@@ -12,7 +12,7 @@
 
     # atom tracker
     atom_fluxes = atom_exchange(sol, model)
-    @test isapprox(atom_fluxes["C"], 37.1902; atol=TEST_TOLERANCE)
+    @test isapprox(atom_fluxes["C"], 37.19016648975907; atol=TEST_TOLERANCE)
     @test atom_exchange("FBA", model)["C"] == 0.0
     @test isapprox(atom_exchange("BIOMASS_Ecoli_core_w_GAM", model)["C"], -42.5555; atol=TEST_TOLERANCE)
     


### PR DESCRIPTION
Add a function to get the atoms exchanged by a reaction (should be zero for all reactions except the biomass and boundary reactions). See #311 

Also fix issue with `atom_exchange` when applied to overall flux distribution.

Closes #311 when merged.