### PR TITLE
🩹 Make `atom_exchage` robust to metabolites missing formulas

### DIFF
--- a/src/base/utils/Metabolite.jl
+++ b/src/base/utils/Metabolite.jl
@@ -2,5 +2,7 @@
     get_atoms(met::Metabolite)::MetaboliteFormula
 
 Simple wrapper for getting the atom dictionary count out of a `Metabolite`.
+
+See also: [`metabolite_formula`](@ref)
 """
 get_atoms(met::Metabolite)::MetaboliteFormula = _maybemap(_parse_formula, met.formula)

--- a/src/base/utils/Reaction.jl
+++ b/src/base/utils/Reaction.jl
@@ -61,7 +61,7 @@ function is_mass_balanced(rxn::Reaction, model::StandardModel)
     atom_balances = Dict{String,Float64}() # float here because stoichiometry is not Int
     for (met, stoich) in rxn.metabolites
         atoms = metabolite_formula(model, met)
-        isempty(atoms) && continue # ignore blanks
+        isnothing(atoms) && continue # ignore blanks
         for (k, v) in atoms
             atom_balances[k] = get(atom_balances, k, 0) + v * stoich
         end

--- a/src/base/utils/Reaction.jl
+++ b/src/base/utils/Reaction.jl
@@ -60,7 +60,7 @@ See also: [`get_atoms`](@ref), [`check_duplicate_reaction`](@ref)
 function is_mass_balanced(rxn::Reaction, model::StandardModel)
     atom_balances = Dict{String,Float64}() # float here because stoichiometry is not Int
     for (met, stoich) in rxn.metabolites
-        atoms = get_atoms(model.metabolites[met])
+        atoms = metabolite_formula(model, met)
         isempty(atoms) && continue # ignore blanks
         for (k, v) in atoms
             atom_balances[k] = get(atom_balances, k, 0) + v * stoich

--- a/src/base/utils/StandardModel.jl
+++ b/src/base/utils/StandardModel.jl
@@ -57,7 +57,8 @@ function atom_exchange(flux_dict::Dict{String,Float64}, model::StandardModel)
     for (rxn_id, flux) in flux_dict
         if is_boundary(model.reactions[rxn_id])
             for (met, stoich_rxn) in model.reactions[rxn_id].metabolites
-                adict = get_atoms(model.metabolites[met])
+                adict = metabolite_formula(model, met)
+                isnothing(adict) && continue
                 for (atom, stoich_molecule) in adict
                     atom_flux[atom] =
                         get(atom_flux, atom, 0.0) + flux * stoich_rxn * stoich_molecule
@@ -76,7 +77,8 @@ Return a dictionary mapping the flux of atoms through a reaction in `model`.
 function atom_exchange(rxn_id::String, model::StandardModel)
     atom_flux = Dict{String,Float64}()
     for (met, stoich_rxn) in model.reactions[rxn_id].metabolites
-        adict = get_atoms(model.metabolites[met])
+        adict = metabolite_formula(model, met)
+        isnothing(adict) && continue
         for (atom, stoich_molecule) in adict
             atom_flux[atom] = get(atom_flux, atom, 0.0) + stoich_rxn * stoich_molecule
         end


### PR DESCRIPTION
Addresses #326 by adding a continue clause for `atom_exchange`

Closes #326 when merged.
