### PR TITLE
better errors for optimizer mods

### DIFF
--- a/src/analysis/modifications/optimizer.jl
+++ b/src/analysis/modifications/optimizer.jl
@@ -59,6 +59,7 @@ Change the lower and upper bounds (`lb` and `ub` respectively) of reaction `id`.
 function change_constraint(id::String, lb, ub)
     (model, opt_model) -> begin
         ind = first(indexin([id], reactions(model)))
+        isnothing(ind) && throw(DomainError(id, "No matching reaction was found."))
         set_optmodel_bound!(ind, opt_model, lb = lb, ub = ub)
     end
 end
@@ -87,6 +88,8 @@ function change_objective(
             objective_indices =
                 [first(indexin([rxnid], reactions(model))) for rxnid in new_objective]
         end
+
+        any(isnothing.(objective_indices)) && throw(DomainError(new_objective, "No matching reaction found for one or more ids."))
 
         # Initialize weights
         opt_weights = spzeros(n_reactions(model))

--- a/test/analysis/flux_balance_analysis.jl
+++ b/test/analysis/flux_balance_analysis.jl
@@ -67,6 +67,30 @@ end
         31.999999998962604,
         atol = TEST_TOLERANCE,
     )
+
+    @test_throws DomainError flux_balance_analysis_dict(
+                                model,
+                                Tulip.Optimizer;
+                                modifications = [
+                                    change_constraint("gbbrsh", -12, -12)
+                                ],
+                            )
+    @test_throws DomainError flux_balance_analysis_dict(
+                                model,
+                                Tulip.Optimizer;
+                                modifications = [
+                                    change_objective("gbbrsh")
+                                ],
+                            )
+    @test_throws DomainError flux_balance_analysis_dict(
+                                model,
+                                Tulip.Optimizer;
+                                modifications = [
+                                    change_objective(
+                                        ["BIOMASS_Ecoli_core_w_GAM"; "gbbrsh"]
+                                    )
+                                ],
+                            )
 end
 
 @testset "Flux balance analysis with CoreModelCoupled" begin


### PR DESCRIPTION
# Description of the proposed change

Informative errors when `change_constraint` or `change_objective` are called with reaction ids that are not in the model. This should fix #319.

Are there other places where similar problems might occur?

