### PR TITLE
do not deploy notebook build artifacts to docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -111,6 +111,9 @@ for (root, dirs, files) in walkdir(joinpath(@__DIR__, "build", "notebooks"))
     end
 end
 
+# also remove the index template
+rm(joinpath(@__DIR__, "build", "index.md.template"))
+
 # deploy the result
 deploydocs(
     repo = "github.com/$(ENV["TRAVIS_REPO_SLUG"]).git",


### PR DESCRIPTION
removes a lot of danger from possibly leaking github tokens (as has actually happened)

I will force-clean the `gh-pages` branch once this is merged.