### PR TITLE
unsupport `name` field in models

### DIFF
--- a/src/base/types/Gene.jl
+++ b/src/base/types/Gene.jl
@@ -4,17 +4,15 @@ Gene struct.
 # Fields
 ````
 id :: String
-name :: Union{String, Nothing}
 notes :: Dict{String, Vector{String}}
 annotation :: Dict{String, Union{Vector{String}, String}}
 ````
 """
 mutable struct Gene
     id::String
-    name::Maybe{String}
     notes::Notes
     annotations::Annotations
 
-    Gene(id::String = ""; name = nothing, notes = Notes(), annotations = Annotations()) =
-        new(id, name, notes, annotations)
+    Gene(id::String = ""; notes = Notes(), annotations = Annotations()) =
+        new(id, notes, annotations)
 end

--- a/src/base/types/Metabolite.jl
+++ b/src/base/types/Metabolite.jl
@@ -4,7 +4,6 @@ Metabolite structure.
 # Fields
 ````
 id :: String
-name :: String
 formula :: String
 charge :: Int
 compartment :: String
@@ -14,7 +13,6 @@ annotation :: Dict{String, Union{Vector{String}, String}}
 """
 mutable struct Metabolite
     id::String
-    name::Maybe{String}
     formula::Maybe{String}
     charge::Maybe{Int}
     compartment::Maybe{String}
@@ -23,11 +21,10 @@ mutable struct Metabolite
 
     Metabolite(
         id = "";
-        name = nothing,
         formula = nothing,
         charge = nothing,
         compartment = nothing,
         notes = Notes(),
         annotations = Annotations(),
-    ) = new(id, name, formula, charge, compartment, notes, annotations)
+    ) = new(id, formula, charge, compartment, notes, annotations)
 end

--- a/src/base/types/Reaction.jl
+++ b/src/base/types/Reaction.jl
@@ -1,7 +1,6 @@
 """
     mutable struct Reaction
         id::String
-        name::Maybe{String}
         metabolites::Dict{String,Float64}
         lb::Float64
         ub::Float64
@@ -16,7 +15,6 @@ A structure for representing a single reaction in a [`StandardModel`](@ref).
 """
 mutable struct Reaction
     id::String
-    name::Maybe{String}
     metabolites::Dict{String,Float64}
     lb::Float64
     ub::Float64
@@ -30,7 +28,6 @@ end
 """
     Reaction(
         id = "";
-        name = nothing,
         metabolites = Dict{String,Float64}(),
         lb = -_constants.default_reaction_bound,
         ub = _constants.default_reaction_bound,
@@ -47,7 +44,6 @@ explicitely assigned.
 """
 function Reaction(
     id = "";
-    name = nothing,
     metabolites = Dict{String,Float64}(),
     lb = -_constants.default_reaction_bound,
     ub = _constants.default_reaction_bound,
@@ -60,7 +56,6 @@ function Reaction(
     mets = Dict(k => float(v) for (k, v) in metabolites)
     return Reaction(
         id,
-        name,
         mets,
         lb,
         ub,

--- a/src/base/types/StandardModel.jl
+++ b/src/base/types/StandardModel.jl
@@ -301,7 +301,7 @@ function Base.convert(::Type{StandardModel}, model::MetabolicModel)
             gid;
             notes = gene_notes(model, gid),
             annotations = gene_annotations(model, gid),
-        ) # TODO: add name accessor
+        )
     end
 
     for mid in metids
@@ -333,7 +333,7 @@ function Base.convert(::Type{StandardModel}, model::MetabolicModel)
             notes = reaction_notes(model, rid),
             annotations = reaction_annotations(model, rid),
             subsystem = reaction_subsystem(model, rid),
-        ) # TODO: add name accessor
+        )
     end
 
     return StandardModel(

--- a/src/base/utils/StandardModel.jl
+++ b/src/base/utils/StandardModel.jl
@@ -18,7 +18,6 @@ Shallow copy of a [`Reaction`](@ref)
 """
 Base.copy(r::Reaction) = Reaction(
     r.id;
-    name = r.name,
     metabolites = r.metabolites,
     lb = r.lb,
     ub = r.ub,
@@ -36,7 +35,6 @@ Shallow copy of a [`Metabolite`](@ref)
 """
 Base.copy(m::Metabolite) = Metabolite(
     m.id;
-    name = m.name,
     formula = m.formula,
     charge = m.charge,
     compartment = m.compartment,
@@ -49,7 +47,7 @@ Base.copy(m::Metabolite) = Metabolite(
 
 Shallow copy of a [`Gene`](@ref)
 """
-Base.copy(g::Gene) = Gene(g.id; name = g.name, notes = g.notes, annotations = g.annotations)
+Base.copy(g::Gene) = Gene(g.id; notes = g.notes, annotations = g.annotations)
 
 """
     atom_exchange(model::StandardModel, rxn_id::String)

--- a/src/reconstruction/CoreModelCoupled.jl
+++ b/src/reconstruction/CoreModelCoupled.jl
@@ -202,8 +202,7 @@ end
 
 """
 function remove_reactions(m::CoreModelCoupled, rxns::Vector{String})
-    rxn_indices =
-        [findfirst(isequal(name), m.lm.rxns) for name in intersect(rxns, m.lm.rxns)]
+    rxn_indices = [findfirst(isequal(rid), m.lm.rxns) for rid in intersect(rxns, m.lm.rxns)]
     if isempty(rxn_indices)
         return m
     else

--- a/test/base/types/Gene.jl
+++ b/test/base/types/Gene.jl
@@ -2,23 +2,16 @@
     g = Gene()
 
     # test defaults
-    @test isnothing(g.name)
     @test isempty(g.notes)
     @test isempty(g.annotations)
 
     # Now assign
     g.id = "gene1"
-    g.name = "gene_name"
     g.notes = Dict("notes" => ["blah", "blah"])
     g.annotations = Dict("sboterm" => ["sbo"], "ncbigene" => ["ads", "asds"])
 
     # Test pretty printing
-    @test all(
-        contains.(
-            sprint(show, MIME("text/plain"), g),
-            ["gene1", "gene_name", "blah", "asds"],
-        ),
-    )
+    @test all(contains.(sprint(show, MIME("text/plain"), g), ["gene1", "blah", "asds"]))
 
     # Test duplicate annotation finder
     g2 = Gene("gene2")

--- a/test/base/types/Metabolite.jl
+++ b/test/base/types/Metabolite.jl
@@ -1,7 +1,6 @@
 @testset "Metabolite" begin
     m1 = Metabolite()
     m1.id = "met1"
-    m1.name = "metabolite 1"
     m1.formula = "C6H12O6N"
     m1.charge = 1
     m1.compartment = "c"
@@ -11,7 +10,7 @@
     @test all(
         contains.(
             sprint(show, MIME("text/plain"), m1),
-            ["met1", "metabolite 1", "C6H12O6N", "blah", "asds"],
+            ["met1", "C6H12O6N", "blah", "asds"],
         ),
     )
 

--- a/test/base/types/Reaction.jl
+++ b/test/base/types/Reaction.jl
@@ -20,7 +20,6 @@
 
     r1 = Reaction()
     r1.id = "r1"
-    r1.name = "reaction 1"
     r1.metabolites = Dict(m1.id => -1.0, m2.id => 1.0)
     r1.lb = -100.0
     r1.ub = 100.0
@@ -33,7 +32,7 @@
     @test all(
         contains.(
             sprint(show, MIME("text/plain"), r1),
-            ["r1", "reaction 1", "100.0", "g1 and g2", "glycolysis", "blah", "biocyc"],
+            ["r1", "100.0", "g1 and g2", "glycolysis", "blah", "biocyc"],
         ),
     )
 

--- a/test/base/types/StandardModel.jl
+++ b/test/base/types/StandardModel.jl
@@ -19,7 +19,6 @@
 
     r1 = Reaction()
     r1.id = "r1"
-    r1.name = "reaction 1"
     r1.metabolites = Dict(m1.id => -1.0, m2.id => 1.0)
     r1.lb = -100.0
     r1.ub = 100.0
@@ -35,7 +34,7 @@
     r4.annotations = Dict("sboterm" => ["sbo"], "biocyc" => ["ads", "asds"])
 
     mets = [m1, m2, m3, m4]
-    gs = [g1, g2, g3] # DO NOT name variables the names of accessor functions!
+    gs = [g1, g2, g3]
     rxns = [r1, r2, r3, r4]
 
     model = StandardModel()


### PR DESCRIPTION
It looks great but we aren't going to support it in core MetabolicModel
interface. Moreover, it's only a prettification, which the users may manage
externally.

Closes #392 (name support will be implemented elsewhere)

