### PR TITLE
simplify code by removing unnecessary unicode

### DIFF
--- a/docs/src/notebooks/5_basic_stdmodel_construction.jl
+++ b/docs/src/notebooks/5_basic_stdmodel_construction.jl
@@ -63,6 +63,15 @@ end
 
 model.reactions["r4"].grr = [["g5"], ["g6", "g7"], ["g8"]]
 
+#md # !!! note "Note: Writing unicode arrows"
+#md #     The reaction arrows can be easily written by using the `LaTeX`
+#md #     completions built into Julia shell (and many Julia-compatible
+#md #     editors). You can type:
+#md #
+#md #     - `→` as `\rightarrow` (press `Tab` to complete)
+#md #     - `←` as `\leftarrow`
+#md #     - `↔` as `\leftrightarrow`
+
 # The constructed model can now be inspected.
 model
 

--- a/docs/src/notebooks/5_basic_stdmodel_construction.jl
+++ b/docs/src/notebooks/5_basic_stdmodel_construction.jl
@@ -41,7 +41,7 @@ add_metabolites!(model, metabolite_list)
 # There are two ways to create and add reactions to a model.
 # These are using functions, or macros.
 
-r_m1 = Reaction("EX_m1", Dict("m1" => -1.0), :bidirectional) # exchange reaction: m1 <-> (is the same as m1 ⟷ nothing)
+r_m1 = Reaction("EX_m1", Dict("m1" => -1.0), :bidirectional) # exchange reaction: m1 <-> (is the same as m1 ↔ nothing)
 r1 = Reaction("r1", Dict("m1" => -1.0, "m2" => 1.0), :forward)
 r1.grr = [["g1", "g2"], ["g3"]] # add some gene reaction rules
 r2 = Reaction("r2", Dict("m2" => -1.0, "m1" => 1.0), :backward)
@@ -55,27 +55,13 @@ m3 = metabolite_list[3]
 m4 = metabolite_list[4]
 
 @add_reactions! model begin # macro approach
-    "r4", m2 ⟶ m4, 0, 1000
-    "r_m3", m3 ⟷ nothing, -1000, 1000
-    "r_m4", m4 ⟶ nothing
-    "r5", m4 ⟶ m2
+    "r4", m2 → m4, 0, 1000
+    "r_m3", m3 ↔ nothing, -1000, 1000
+    "r_m4", m4 → nothing
+    "r5", m4 → m2
 end
 
 model.reactions["r4"].grr = [["g5"], ["g6", "g7"], ["g8"]]
-
-#md # !!! note "Note: Using reaction arrows"
-#md #       `COBREXA` exports arrows that can be used to construct reactions.
-#md #       Both the long and short arrows (`⟶ == →`) mean the same thing if they
-#md #       point in the same direction.
-#md #
-#md #       These arrows are accessible by using the `LaTeX` completions built into
-#md #       Julia. For example:
-#md #       1. → is \rightarrow<tab>
-#md #       2. ⟶ is \longrightarrow<tab>
-#md #       3. ← is \leftarrow<tab>
-#md #       4. ⟵ is \longleftarrow<tab>
-#md #       5. ↔ is \leftrightarrow<tab>
-#md #       6. ⟷ is \longleftrightarrow<tab>
 
 # The constructed model can now be inspected.
 model

--- a/src/analysis/flux_balance_analysis.jl
+++ b/src/analysis/flux_balance_analysis.jl
@@ -43,7 +43,7 @@ s.t. S x = b
      xₗ ≤ x ≤ xᵤ
 ```
 See "Orth, J., Thiele, I. & Palsson, B. What is flux balance analysis?. Nat
-Biotechnol 28, 245–248 (2010). https://doi.org/10.1038/nbt.1614" for more
+Biotechnol 28, 245-248 (2010). https://doi.org/10.1038/nbt.1614" for more
 information.
 
 The `optimizer` must be set to a `JuMP`-compatible optimizer, such as

--- a/src/analysis/modifications/optimizer.jl
+++ b/src/analysis/modifications/optimizer.jl
@@ -45,9 +45,9 @@ with [`objective_bounds`](@ref).
 """
 function constrain_objective_value(tolerance)
     return (model, opt_model) -> begin
-        λmin, λmax = objective_bounds(tolerance)(objective_value(opt_model))
+        lambda_min, lambda_max = objective_bounds(tolerance)(objective_value(opt_model))
         old_objective = objective_function(opt_model)
-        @constraint(opt_model, λmin <= sum(old_objective) <= λmax)
+        @constraint(opt_model, lambda_min <= sum(old_objective) <= lambda_max)
     end
 end
 

--- a/src/analysis/parsimonious_flux_balance_analysis.jl
+++ b/src/analysis/parsimonious_flux_balance_analysis.jl
@@ -24,10 +24,10 @@ s.t. S x = b
 Where the optimal solution of the FBA problem, μ⁰, has been added as an
 additional constraint. See "Lewis, Nathan E, Hixson, Kim K, Conrad, Tom M,
 Lerman, Joshua A, Charusanti, Pep, Polpitiya, Ashoka D, Adkins, Joshua N,
-Schramm, Gunnar, Purvine, Samuel O, Lopez‐Ferrer, Daniel, Weitz, Karl K, Eils,
+Schramm, Gunnar, Purvine, Samuel O, Lopez-Ferrer, Daniel, Weitz, Karl K, Eils,
 Roland, König, Rainer, Smith, Richard D, Palsson, Bernhard Ø, (2010) Omic data
 from evolved E. coli are consistent with computed optimal growth from
-genome‐scale models. Molecular Systems Biology, 6. 390. doi:
+genome-scale models. Molecular Systems Biology, 6. 390. doi:
 accession:10.1038/msb.2010.47" for more details.
 
 pFBA gets the model optimum by standard FBA (using

--- a/src/analysis/sampling/affine_hit_and_run.jl
+++ b/src/analysis/sampling/affine_hit_and_run.jl
@@ -99,8 +99,8 @@ function _affine_hit_and_run_chain(warmup, lbs, ubs, iters, chain)
 
                 # iteratively collect the maximum and minimum possible multiple
                 # of `dir` added to the current point
-                λmax = Inf
-                λmin = -Inf
+                lambda_max = Inf
+                lambda_min = -Inf
                 for j = 1:d
                     dl = lbs[j] - points[j, i]
                     du = ubs[j] - points[j, i]
@@ -115,13 +115,13 @@ function _affine_hit_and_run_chain(warmup, lbs, ubs, iters, chain)
                         lower = -Inf
                         upper = Inf
                     end
-                    λmin = max(λmin, lower)
-                    λmax = min(λmax, upper)
+                    lambda_min = max(lambda_min, lower)
+                    lambda_max = min(lambda_max, upper)
                 end
 
-                λ = λmin + rand() * (λmax - λmin)
-                !isfinite(λ) && continue # avoid divergence
-                new_points[:, i] = points[:, i] .+ λ .* dir
+                lambda = lambda_min + rand() * (lambda_max - lambda_min)
+                !isfinite(lambda) && continue # avoid divergence
+                new_points[:, i] = points[:, i] .+ lambda .* dir
 
                 # TODO normally, here we would check if sum(S*new_point) is still
                 # lower than the tolerance, but we shall trust the computer

--- a/src/io/show/Reaction.jl
+++ b/src/io/show/Reaction.jl
@@ -16,13 +16,13 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", r::Reaction)
     if r.ub > 0.0 && r.lb < 0.0
-        arrow = " ⟷  "
+        arrow = " ↔  "
     elseif r.ub <= 0.0 && r.lb < 0.0
-        arrow = " ⟵  "
+        arrow = " ←  "
     elseif r.ub > 0.0 && r.lb >= 0.0
-        arrow = " ⟶  "
+        arrow = " →  "
     else
-        arrow = " →∣←  " # blocked reaction
+        arrow = " →|←  " # blocked reaction
     end
     substrates =
         ["$(-v) $k" for (k, v) in Iterators.filter(((_, v)::Pair -> v < 0), r.metabolites)]

--- a/src/reconstruction/CoreModel.jl
+++ b/src/reconstruction/CoreModel.jl
@@ -290,7 +290,7 @@ m4 = remove_metabolites(model, first(indexin(["glc__D_e"], metabolites(model))))
 ```
 """
 function remove_metabolites(model::CoreModel, mets)
-    mets_to_keep = filter(x -> x ∉ mets, 1:n_metabolites(model))
+    mets_to_keep = filter(!in(mets), 1:n_metabolites(model))
     temp_S = model.S[mets_to_keep, :]
 
     (I, rxns_to_keep, val) = findnz(temp_S)
@@ -331,7 +331,7 @@ Removes a set of reactions from a CoreModel.
 Also removes the metabolites not involved in any reaction.
 """
 function remove_reactions(m::CoreModel, rxns::Vector{Int})
-    rxns_to_keep = filter(e -> e ∉ rxns, 1:n_reactions(m))
+    rxns_to_keep = filter(!in(rxns), 1:n_reactions(m))
     temp_s = m.S[:, rxns_to_keep]
 
     (mets_to_keep, J, val) = findnz(temp_s)

--- a/src/reconstruction/CoreModelCoupled.jl
+++ b/src/reconstruction/CoreModelCoupled.jl
@@ -175,7 +175,7 @@ Also removes any metabolites not involved in any reaction after the deletion.
 function remove_reactions(m::CoreModelCoupled, rxns::Vector{Int})
     return CoreModelCoupled(
         remove_reactions(m.lm, rxns),
-        m.C[:, filter(e -> e ∉ rxns, 1:n_reactions(m))],
+        m.C[:, filter(!in(rxns), 1:n_reactions(m))],
         m.cl,
         m.cu,
     )
@@ -319,7 +319,7 @@ Removes a set of coupling constraints from a [`CoreModelCoupled`](@ref)
 in-place.
 """
 function remove_coupling_constraints!(m::CoreModelCoupled, constraints::Vector{Int})
-    to_be_kept = filter(e -> e ∉ constraints, 1:n_coupling_constraints(m))
+    to_be_kept = filter(!in(constraints), 1:n_coupling_constraints(m))
     m.C = m.C[to_be_kept, :]
     m.cl = m.cl[to_be_kept]
     m.cu = m.cu[to_be_kept]
@@ -343,7 +343,7 @@ function change_coupling_bounds!(
     cl::V = Float64[],
     cu::V = Float64[],
 ) where {V<:VecType}
-    found = [index ∈ 1:n_coupling_constraints(model) for index in constraints]
+    found = (constraints .>= 1) .& (constraints .<= n_coupling_constraints(model))
     red_constraints = constraints[found]
 
     length(red_constraints) == length(unique(red_constraints)) ||

--- a/src/reconstruction/Reaction.jl
+++ b/src/reconstruction/Reaction.jl
@@ -62,7 +62,7 @@ function _mkrxn(substrates, products)
 end
 
 """
-    ⟶(
+    →(
         substrates::Union{
             Nothing,
             Metabolite,
@@ -78,9 +78,8 @@ end
     )
 
 Make a forward-only [`Reaction`](@ref) from `substrates` and `products`.
-An equivalent alternative is `→`.
 """
-function ⟶(
+function →(
     substrates::Union{
         Nothing,
         Metabolite,
@@ -97,10 +96,9 @@ function ⟶(
     metdict = _mkrxn(substrates, products)
     return Reaction("", metdict, :forward)
 end
-const → = ⟶
 
 """
-    ⟵(
+    ←(
         substrates::Union{
             Nothing,
             Metabolite,
@@ -116,9 +114,8 @@ const → = ⟶
     )
 
 Make a reverse-only [`Reaction`](@ref) from `substrates` and `products`.
-An equivalent alternative is `←`.
 """
-function ⟵(
+function ←(
     substrates::Union{
         Nothing,
         Metabolite,
@@ -135,10 +132,9 @@ function ⟵(
     metdict = _mkrxn(substrates, products)
     return Reaction("", metdict, :reverse)
 end
-const ← = ⟵
 
 """
-    ⟷(
+    ↔(
         substrates::Union{
             Nothing,
             Metabolite,
@@ -153,10 +149,10 @@ const ← = ⟵
         },
     )
 
-Make a bidirectional (reversible) [`Reaction`](@ref) from `substrates` and `products`.
-An equivalent alternative is `↔`.
+Make a bidirectional (reversible) [`Reaction`](@ref) from `substrates` and
+`products`.
 """
-function ⟷(
+function ↔(
     substrates::Union{
         Nothing,
         Metabolite,
@@ -173,4 +169,3 @@ function ⟷(
     metdict = _mkrxn(substrates, products)
     return Reaction("", metdict, :bidirectional)
 end
-const ↔ = ⟷

--- a/src/reconstruction/StandardModel.jl
+++ b/src/reconstruction/StandardModel.jl
@@ -77,9 +77,9 @@ Examples
 --------
 ```
 @add_reactions! model begin
-    "v1", nothing ⟶ A, 0, 500
-    "v2", A ⟷ B + C, -500
-    "v3", B + C ⟶ nothing
+    "v1", nothing → A, 0, 500
+    "v2", A ↔ B + C, -500
+    "v3", B + C → nothing
 end
 ```
 """

--- a/test/reconstruction/CoreModel.jl
+++ b/test/reconstruction/CoreModel.jl
@@ -231,8 +231,8 @@ end
     @test size(stoichiometry(m2)) == (71, 94)
     @test size(stoichiometry(m3)) == (70, 94)
     @test size(stoichiometry(m4)) == (71, 94)
-    @test any(["glc__D_e", "for_c"] .∉ Ref(metabolites(m1)))
-    @test any(["glc__D_e"] .∉ Ref(metabolites(m2)))
-    @test any(["glc__D_e", "for_c"] .∉ Ref(metabolites(m3)))
-    @test any(["glc__D_e"] .∉ Ref(metabolites(m4)))
+    @test all((!in(metabolites(m1))).(["glc__D_e", "for_c"]))
+    @test !(["glc__D_e"] in metabolites(m2))
+    @test all((!in(metabolites(m3))).(["glc__D_e", "for_c"]))
+    @test !(["glc__D_e"] in metabolites(m4))
 end

--- a/test/reconstruction/Reaction.jl
+++ b/test/reconstruction/Reaction.jl
@@ -9,7 +9,7 @@
     nad = model.metabolites["nad_c"]
     h_p = model.metabolites["h_p"]
 
-    rxn = nadh + 4.0 * h_c + 1.0 * q8 ⟶ 1.0 * q8h2 + 1.0 * nad + 3.0 * h_p
+    rxn = nadh + 4.0 * h_c + 1.0 * q8 → 1.0 * q8h2 + 1.0 * nad + 3.0 * h_p
     @test rxn.lb == 0.0 && rxn.ub > 0.0
 
     rxn = 1.0 * nadh + 4.0 * h_c + q8 ← 1.0 * q8h2 + 1.0 * nad + 3.0 * h_p
@@ -27,11 +27,11 @@
     rxn = nothing → 1.0nadh
     @test length(rxn.metabolites) == 1
 
-    rxn = 1.0 * nadh + 4.0 * h_c + 1.0 * q8 ⟶ 1.0 * q8h2 + 1.0 * nad + 3.0 * h_p
+    rxn = 1.0 * nadh + 4.0 * h_c + 1.0 * q8 → 1.0 * q8h2 + 1.0 * nad + 3.0 * h_p
     @test prod(values(rxn.metabolites)) == -12
     @test ("q8h2_c" in [x for x in keys(rxn.metabolites)])
 
-    rxn = nadh + 4.0 * h_c + 1.0 * q8 ⟶ 1.0 * q8h2 + 1.0 * nad + 3.0 * h_p
+    rxn = nadh + 4.0 * h_c + 1.0 * q8 → 1.0 * q8h2 + 1.0 * nad + 3.0 * h_p
     @test rxn.lb == 0.0 && rxn.ub > 0.0
 
     @test length(h_p + h_p) == 2

--- a/test/reconstruction/add_reactions.jl
+++ b/test/reconstruction/add_reactions.jl
@@ -6,9 +6,9 @@
     add_metabolites!(mod, [A, B, C])
 
     @add_reactions! mod begin
-        "v1", nothing ⟷ A
-        "v2", nothing ⟷ B, -500
-        "v3", nothing ⟷ C, -500, 500
+        "v1", nothing ↔ A
+        "v2", nothing ↔ B, -500
+        "v3", nothing ↔ C, -500, 500
     end
 
     rxn = mod.reactions["v1"]


### PR DESCRIPTION
- unify arrows to a single form →
- remove lots of other unicode from code