### PR TITLE
implement objective envelopes (aka production envelopes)

### DIFF
--- a/src/analysis/envelopes.jl
+++ b/src/analysis/envelopes.jl
@@ -1,0 +1,40 @@
+
+envelope_lattice(m::MetabolicModel, rids::Vector{String}; kwargs...) =
+    envelope_lattice(m, Vector{Int}(indexin(rids, reactions(m))); kwargs...)
+
+envelope_lattice(
+    m::MetabolicModel,
+    ridxs::Vector{Int};
+    samples = 10,
+    ranges = collect(zip(bounds(m)...))[ridxs],
+    reaction_samples = fill(samples, length(ridxs))) =
+    (
+        lb .+ (ub - lb) .* ((1:s) .- 1) ./ max(s - 1, 1) for
+        (s, (lb, ub)) in zip(reaction_samples, ranges)
+    )
+
+objective_envelope(m::MetabolicModel, rids::Vector{String}, args...; kwargs...) =
+    objective_envelope(m, Vector{Int}(indexin(rids, reactions(m))), args...; kwargs...)
+
+objective_envelope(
+    m::MetabolicModel,
+    ridxs::Vector{Int},
+    optimizer;
+    lattice = envelope_lattice(m, ridxs),
+    kwargs...,
+) = (
+    lattice = collect.(lattice),
+    values = screen_optmodel_modifications(
+        m,
+        optimizer,
+        modifications = collect(
+            [(_, optmodel) -> begin
+                    for (i, ridx) in enumerate(ridxs)
+                        set_normalized_rhs(optmodel[:lbs][ridx], bounds[i])
+                        set_normalized_rhs(optmodel[:ubs][ridx], bounds[i])
+                    end
+                end] for bounds in Iterators.product(lattice...)
+        ),
+        analysis = screen_optimize_objective,
+    ),
+)

--- a/src/analysis/envelopes.jl
+++ b/src/analysis/envelopes.jl
@@ -1,31 +1,90 @@
 
-envelope_lattice(m::MetabolicModel, rids::Vector{String}; kwargs...) =
-    envelope_lattice(m, Vector{Int}(indexin(rids, reactions(m))); kwargs...)
+"""
+    envelope_lattice(model::MetabolicModel, rids::Vector{String}; kwargs...)
 
-envelope_lattice(
-    m::MetabolicModel,
-    ridxs::Vector{Int};
-    samples = 10,
-    ranges = collect(zip(bounds(m)...))[ridxs],
-    reaction_samples = fill(samples, length(ridxs))) =
-    (
-        lb .+ (ub - lb) .* ((1:s) .- 1) ./ max(s - 1, 1) for
-        (s, (lb, ub)) in zip(reaction_samples, ranges)
+Version of [`envelope_lattice`](@ref) that works on string reaction IDs instead
+of integer indexes.
+"""
+envelope_lattice(model::MetabolicModel, rids::Vector{String}; kwargs...) =
+    envelope_lattice(model, Vector{Int}(indexin(rids, reactions(model))); kwargs...)
+
+"""
+    envelope_lattice(
+        model::MetabolicModel,
+        ridxs::Vector{Int};
+        samples = 10,
+        ranges = collect(zip(bounds(model)...))[ridxs],
+        reaction_samples = fill(samples, length(ridxs)),
     )
 
-objective_envelope(m::MetabolicModel, rids::Vector{String}, args...; kwargs...) =
-    objective_envelope(m, Vector{Int}(indexin(rids, reactions(m))), args...; kwargs...)
+Create a lattice (list of "tick" vectors) for reactions at indexes `ridxs` in a
+model. Arguments `samples`, `ranges`, and `reaction_samples` may be optionally
+specified to customize the latice creation process.
+"""
+envelope_lattice(
+    model::MetabolicModel,
+    ridxs::Vector{Int};
+    samples = 10,
+    ranges = collect(zip(bounds(model)...))[ridxs],
+    reaction_samples = fill(samples, length(ridxs)),
+) = (
+    lb .+ (ub - lb) .* ((1:s) .- 1) ./ max(s - 1, 1) for
+    (s, (lb, ub)) in zip(reaction_samples, ranges)
+)
 
+"""
+    objective_envelope(model::MetabolicModel, rids::Vector{String}, args...; kwargs...)
+
+Versioin of [`objective_envelope`](@ref) that works on string reaction IDs
+instead of integer indexes.
+"""
+objective_envelope(model::MetabolicModel, rids::Vector{String}, args...; kwargs...) =
+    objective_envelope(
+        model,
+        Vector{Int}(indexin(rids, reactions(model))),
+        args...;
+        kwargs...,
+    )
+
+"""
+    objective_envelope(
+        model::MetabolicModel,
+        ridxs::Vector{Int},
+        optimizer;
+        lattice = envelope_lattice(model, ridxs),
+        kwargs...,
+    )
+
+Compute an array of objective values for the `model` for rates of reactions
+specified `ridxs` fixed to a regular range of values between their respective
+lower and upper bounds.
+
+This can be used to compute a "production envelope" of a metabolite; but
+generalizes to any specifiable objective and to multiple dimensions of the
+examined space. To retrieve a production envelope of any metabolite, set the
+objective coefficient vector of the `model` to a vector that contains a single
+`1` for the exchange reaction that "outputs" this metabolite, and run
+[`objective_envelope`](@ref) with the exchange reaction of the "parameter"
+metabolite specified in `ridxs`.
+
+Returns a named tuple that contains `lattice` with reference values of the
+metabolites, and an N-dimensional array `values` with the computed objective
+values, where N is the number of specified reactions.  Because of the
+increasing dimensionality, the computation gets very voluminous with increasing
+length of `ridxs`.
+
+`kwargs` are internally forwarded to [`screen_optmodel_modifications`](@ref).
+"""
 objective_envelope(
-    m::MetabolicModel,
+    model::MetabolicModel,
     ridxs::Vector{Int},
     optimizer;
-    lattice = envelope_lattice(m, ridxs),
+    lattice = envelope_lattice(model, ridxs),
     kwargs...,
 ) = (
     lattice = collect.(lattice),
     values = screen_optmodel_modifications(
-        m,
+        model,
         optimizer,
         modifications = collect(
             [(_, optmodel) -> begin
@@ -35,6 +94,7 @@ objective_envelope(
                     end
                 end] for bounds in Iterators.product(lattice...)
         ),
-        analysis = screen_optimize_objective,
+        analysis = screen_optimize_objective;
+        kwargs...,
     ),
 )

--- a/src/analysis/screening.jl
+++ b/src/analysis/screening.jl
@@ -166,7 +166,9 @@ Screen multiple modifications of the same optimization model.
 
 This function is potentially more efficient than [`screen`](@ref) because it
 avoids making variants of the model structure and remaking of the optimization
-model, but on the other hand can not express the scale of modifications.
+model. On the other hand, modification functions need to keep the optimization
+model in a recoverable state (one that leaves the model usable for the next
+modification), which limits the possible spectrum of modifications applied.
 
 Internally, `model` is distributed to `workers` and transformed into the
 optimization model using [`make_optimization_model`](@ref). With that,

--- a/src/base/solver.jl
+++ b/src/base/solver.jl
@@ -59,6 +59,15 @@ function is_solved(optmodel)
     false
 end
 
+function optimize_objective(optmodel)::Union{Float64,Nothing}
+    optimize!(optmodel)
+    if is_solved(optmodel)
+        objective_value(optmodel)
+    else
+        nothing
+    end
+end
+
 """
     get_optmodel_bounds(opt_model)
 

--- a/test/analysis/envelopes.jl
+++ b/test/analysis/envelopes.jl
@@ -1,0 +1,40 @@
+
+@testset "Envelopes" begin
+    m = load_model(model_paths["e_coli_core.xml"])
+
+    rxns = [1, 2, 3]
+
+    lat = collect.(envelope_lattice(m, rxns; samples = 3))
+    @test lat == [[0, 500, 1000], [-1000, 0, 1000], [-1000, 0, 1000]]
+    @test lat == collect.(envelope_lattice(m, reactions(m)[rxns]; samples = 3))
+
+    vals =
+        objective_envelope(
+            m,
+            reactions(m)[rxns],
+            Tulip.Optimizer;
+            lattice = lat,
+            workers = W,
+        ).values
+
+    @test size(vals) == (3, 3, 3)
+    @test count(isnothing, vals) == 15
+    @test isapprox(
+        filter(!isnothing, vals),
+        [
+            0.0,
+            0.0,
+            0.0,
+            0.704036947,
+            10.053282384,
+            10.053282365,
+            0.0,
+            0.0,
+            0.0,
+            0.873921506,
+            18.664485767,
+            20.412058183,
+        ],
+        atol = TEST_TOLERANCE,
+    )
+end


### PR DESCRIPTION
## Description

There's the nice production envelopes that allow you to look at how much of something gets produced based on how much of certain metabolite goes in. This implements a slightly generalized version. There might be some extra features to implement, e.g. putting only unidirectional bounds of the optimizer.

#### Checklist

Still a draft.

- [x] code is formatted
- [x] Tests work (try with `]test COBREXA`)
- [x] All new functions have proper docstrings
- [x] Documentation builds correctly (try with `cd docs; julia make.jl`)
