### PR TITLE
correctly forward the `workers` parameter

### DIFF
--- a/src/analysis/flux_variability_analysis.jl
+++ b/src/analysis/flux_variability_analysis.jl
@@ -95,6 +95,7 @@ function flux_variability_analysis(
         ),
         args = [-reactions reactions],
         analysis = (_, opt_model, ridx) -> _max_variability_flux(opt_model, ridx, ret),
+        workers = workers,
     )
 end
 


### PR DESCRIPTION
## Description

Amusing.

I wish *this* was the cause of the benchmark slowness. :D