### PR TITLE
completely disable JuMP bridge constraints

### DIFF
--- a/src/base/solver.jl
+++ b/src/base/solver.jl
@@ -16,7 +16,7 @@ function make_optimization_model(model::MetabolicModel, optimizer; sense = MOI.M
     m, n = size(stoichiometry(model))
     xl, xu = bounds(model)
 
-    optimization_model = Model(optimizer)
+    optimization_model = Model(optimizer; bridge_constraints = false)
     @variable(optimization_model, x[i = 1:n])
     @objective(optimization_model, sense, objective(model)' * x)
     @constraint(optimization_model, mb, stoichiometry(model) * x .== balance(model)) # mass balance


### PR DESCRIPTION
We do not use them at all, which is likely gonna hold for some time. This also speeds up the precompilation somewhat, and removes some unneeded overhead from the model logic.