### PR TITLE
improve the ability of screening functions to use precompiled code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-DistributedData = "0.1.3"
+DistributedData = "0.1.4"
 Documenter = "0.26"
 JSON = "0.21"
 JuMP = "0.21"


### PR DESCRIPTION
Among other, this fixes a ~5-20% performance regression for FVA.


#### Checklist

- [x] All code is formatted with
  [JuliaFormatter](https://github.com/domluna/JuliaFormatter.jl)
  (run `using JuliaFormatter; format("path/to/COBREXA.jl");`)
- [x] Tests work (try with `]test COBREXA`)
- [x] All new functions have proper docstrings
