### PR TITLE
Revert "completely disable JuMP bridge constraints"

### DIFF
--- a/src/base/solver.jl
+++ b/src/base/solver.jl
@@ -16,7 +16,7 @@ function make_optimization_model(model::MetabolicModel, optimizer; sense = MOI.M
     m, n = size(stoichiometry(model))
     xl, xu = bounds(model)
 
-    optimization_model = Model(optimizer; bridge_constraints = false)
+    optimization_model = Model(optimizer)
     @variable(optimization_model, x[i = 1:n])
     @objective(optimization_model, sense, objective(model)' * x)
     @constraint(optimization_model, mb, stoichiometry(model) * x .== balance(model)) # mass balance


### PR DESCRIPTION
This reverts commit e99747f6ca279ffe3b5d9e691af76fc79cd90ad4.

Apparently some internal JuMP logic depends on the bridges, preventing e.g.
single-variable objective functions from working with GLPK (and maybe other
solvers). Dodging that is easy, e.g. you can use `@objective(m, Max, x+0)`
instead of one that contains just `x`, but kludges like this should not be
required in the code.