### PR TITLE
bump version to 1.0.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "COBREXA"
 uuid = "babc4406-5200-4a30-9033-bf5ae714c842"
 authors = ["The developers of COBREXA.jl"]
-version = "1.0.5"
+version = "1.0.6"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
this version rollbacks the removal of JuMP bridge constraints, which seems to have caused weird compatibility issues. There are no other changes.