### PR TITLE
fix metabolite vector construction ambiguity

### DIFF
--- a/src/reconstruction/Reaction.jl
+++ b/src/reconstruction/Reaction.jl
@@ -4,7 +4,7 @@ struct MetaboliteWithCoefficient
     MetaboliteWithCoefficient(c, m) = new(float(c), m)
 end
 
-function Base.:*(coeff, met::Metabolite)
+function Base.:*(coeff::Real, met::Metabolite)
     return MetaboliteWithCoefficient(coeff, met)
 end
 


### PR DESCRIPTION
Found by Aqua.

References #389
