### PR TITLE
reorganize the CI, add a bit of documentation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -258,10 +258,10 @@ pages:
     # resolve and build packages from the docs/Project.toml file
     - julia --project=docs -e 'using Pkg; Pkg.resolve(); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();'
 
-    # deploy doc (the without git history)
+    # build and deploy docs (this doesn't upload the gource animation asset)
     - julia --project=docs --color=yes docs/make.jl
 
-    # move to the directory picked up by Gitlab pages (with git history)
+    # move to the directory to be picked up by Gitlab pages (with assets)
     - mv docs/build public
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ variables:
 # Predefined conditions for triggering jobs
 #
 
-.global_trigger_check_incoming_code: &global_trigger_check_incoming_code
+.global_trigger_pull_request: &global_trigger_pull_request
   rules:
     - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
 
@@ -87,7 +87,7 @@ docker:julia1.6:
     - julia --check-bounds=yes --inline=yes --project=@. -e "import Pkg; Pkg.test(; coverage = true)"
   after_script:
     - julia --project=test/coverage test/coverage/coverage-summary.jl
-  <<: *global_trigger_check_incoming_code
+  <<: *global_trigger_pull_request
 
 #
 # The required compatibility test to pass on branches&tags before the docs get
@@ -189,7 +189,7 @@ format:
             -e GITHUB_COMMENT_FORMAT \
             -e GITHUB_COMMENT \
             cloudposse/github-commenter
-  <<: *global_trigger_check_incoming_code
+  <<: *global_trigger_pull_request
 
 #
 # DOCUMENTATION ASSETS
@@ -229,14 +229,11 @@ documentation-assets:gource:
     - julia --project=@. -e 'import Pkg; Pkg.instantiate();'
     - julia --project=@. --color=yes test/doctests.jl
 
-# this gets triggered on pull requests after the tests (to avoid unnecessary
-# double failure if the tests fail already)
 doc-tests-pr:julia1.6:
   stage: documentation
   <<: *global_doctests
-  <<: *global_trigger_check_incoming_code
+  <<: *global_trigger_pull_request
 
-# this gets triggered in comprehensive tests
 doc-tests:julia1.6:
   stage: test
   <<: *global_doctests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,8 @@
 
 stages:
   - test # this checks the viability of the code
-  - docdata # this builds stuff and assets for the documentation
-  - documentation # this builds and deploys the actual documentation
+  - documentation-assets # this builds assets to be included in documentation
+  - documentation # this processes the documentation
   - test-compat # this runs many additional compatibility tests
 
 variables:
@@ -14,22 +14,22 @@ variables:
 # Predefined conditions for triggering jobs
 #
 
-.global_on_check_incoming_code: &global_on_check_incoming_code
+.global_trigger_check_incoming_code: &global_trigger_check_incoming_code
   rules:
     - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
 
-.global_on_build_doc: &global_on_build_doc
+.global_trigger_build_doc: &global_trigger_build_doc
   rules:
     - if: $CI_COMMIT_BRANCH == "develop"
     - if: $CI_COMMIT_TAG =~ /^v/
 
-.global_on_full_tests: &global_on_full_tests
+.global_trigger_full_tests: &global_trigger_full_tests
   rules:
     - if: $CI_COMMIT_BRANCH == "develop"
     - if: $CI_COMMIT_BRANCH == "master"
     - if: $CI_COMMIT_TAG =~ /^v/
 
-.global_on_compat_tests: &global_on_compat_tests
+.global_trigger_compat_tests: &global_trigger_compat_tests
   rules:
     - if: $CI_COMMIT_BRANCH == "master"
 
@@ -87,7 +87,7 @@ docker:julia1.6:
     - julia --check-bounds=yes --inline=yes --project=@. -e "import Pkg; Pkg.test(; coverage = true)"
   after_script:
     - julia --project=test/coverage test/coverage/coverage-summary.jl
-  <<: *global_on_check_incoming_code
+  <<: *global_trigger_check_incoming_code
 
 #
 # The required compatibility test to pass on branches&tags before the docs get
@@ -96,13 +96,13 @@ docker:julia1.6:
 
 linux:julia1.5:
   stage: test
-  <<: *global_on_full_tests
+  <<: *global_trigger_full_tests
   <<: *global_env_julia15
   <<: *global_env_linux
 
 linux:julia1.6:
   stage: test
-  <<: *global_on_full_tests
+  <<: *global_trigger_full_tests
   <<: *global_env_julia16
   <<: *global_env_linux
 
@@ -112,42 +112,42 @@ linux:julia1.6:
 
 windows8:julia1.5:
   stage: test-compat
-  <<: *global_on_compat_tests
+  <<: *global_trigger_compat_tests
   <<: *global_env_julia15
   <<: *global_env_win8
 
 windows8:julia1.6:
   stage: test-compat
-  <<: *global_on_compat_tests
+  <<: *global_trigger_compat_tests
   <<: *global_env_julia16
   <<: *global_env_win8
 
 windows10:julia1.5:
   stage: test-compat
-  <<: *global_on_compat_tests
+  <<: *global_trigger_compat_tests
   <<: *global_env_julia15
   <<: *global_env_win10
 
 windows10:julia1.6:
   stage: test-compat
-  <<: *global_on_compat_tests
+  <<: *global_trigger_compat_tests
   <<: *global_env_julia16
   <<: *global_env_win10
 
 mac:julia1.5:
   stage: test-compat
-  <<: *global_on_compat_tests
+  <<: *global_trigger_compat_tests
   <<: *global_env_julia15
   <<: *global_env_mac
 
 mac:julia1.6:
   stage: test-compat
-  <<: *global_on_compat_tests
+  <<: *global_trigger_compat_tests
   <<: *global_env_julia16
   <<: *global_env_mac
 
 #
-# Code format checker for pull-requests
+# CODE FORMAT CHECKER
 #
 
 format:
@@ -189,14 +189,16 @@ format:
             -e GITHUB_COMMENT_FORMAT \
             -e GITHUB_COMMENT \
             cloudposse/github-commenter
-  <<: *global_on_check_incoming_code
+  <<: *global_trigger_check_incoming_code
 
 #
-# Development history gif built with gource
+# DOCUMENTATION ASSETS
+#
+# This builds the development history gif using gource.
 #
 
-docdata:gource:
-  stage: docdata
+documentation-assets:gource:
+  stage: documentation-assets
   needs: [] # allow faster start
   image: docker:19.03.13
   tags:
@@ -210,28 +212,44 @@ docdata:gource:
     - docker run -v "$PWD":/visualization $CI_REGISTRY/r3/docker/gource
   artifacts:
     paths: ['output.gif']
-  <<: *global_on_build_doc
+  <<: *global_trigger_build_doc
 
 #
-# Run documentation tests
+# DOCUMENTATION TESTS
+#
+# In pull requests, triggered after the tests succeed to avoid unnecessary
+# double failure.  In normal branch testing, these get triggered with normal
+# tests (the error should be visible ASAP). We avoid a separate stage to keep
+# the pipeline parallelizable.
 #
 
-doc-tests:julia1.6:
-  stage: test
+.global_doctests: &global_doctests
   image: $CI_REGISTRY/r3/docker/julia-custom
   script:
     - julia --project=@. -e 'import Pkg; Pkg.instantiate();'
     - julia --project=@. --color=yes test/doctests.jl
-  <<: *global_on_full_tests
+
+# this gets triggered on pull requests after the tests (to avoid unnecessary
+# double failure if the tests fail already)
+doc-tests-pr:julia1.6:
+  stage: documentation
+  <<: *global_doctests
+  <<: *global_trigger_check_incoming_code
+
+# this gets triggered in comprehensive tests
+doc-tests:julia1.6:
+  stage: test
+  <<: *global_doctests
+  <<: *global_trigger_full_tests
 
 #
-# Build and deploy the documentation
+# DOCUMENTATION
 #
 
 pages:
   stage: documentation
   dependencies:
-    - docdata:gource
+    - documentation-assets:gource
       # Note: This dependency is also implied by the stage ordering, but let's
       # be sure. As of Nov 2021, the assets are not used directly, but referred
       # to externally from the docs.
@@ -248,10 +266,13 @@ pages:
   artifacts:
     paths:
       - public
-  <<: *global_on_build_doc
+  <<: *global_trigger_build_doc
 
 #
-# Trigger the test pipeline in external repo
+# EXTERNAL REPOSITORIES
+#
+# This trigger the test pipeline in external repo as defined by gitlab
+# variables.
 #
 
 trigger:
@@ -261,4 +282,4 @@ trigger:
     - privileged
   script:
     - curl --silent --output /dev/null -X POST -F token=$EXTERNAL_REPO_TOKEN -F ref=$EXTERNAL_REPO_BRANCH $EXTERNAL_REPO
-  <<: *global_on_full_tests
+  <<: *global_trigger_full_tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,13 +23,13 @@ variables:
     - if: $CI_COMMIT_BRANCH == "develop"
     - if: $CI_COMMIT_TAG =~ /^v/
 
-.global_on_full_test: &global_on_full_tests
+.global_on_full_tests: &global_on_full_tests
   rules:
     - if: $CI_COMMIT_BRANCH == "develop"
     - if: $CI_COMMIT_BRANCH == "master"
     - if: $CI_COMMIT_TAG =~ /^v/
 
-.global_on_compat_test: &global_on_compat_test
+.global_on_compat_tests: &global_on_compat_tests
   rules:
     - if: $CI_COMMIT_BRANCH == "master"
 
@@ -96,13 +96,13 @@ docker:julia1.6:
 
 linux:julia1.5:
   stage: test
-  <<: *global_on_full_test
+  <<: *global_on_full_tests
   <<: *global_env_julia15
   <<: *global_env_linux
 
 linux:julia1.6:
   stage: test
-  <<: *global_on_full_test
+  <<: *global_on_full_tests
   <<: *global_env_julia16
   <<: *global_env_linux
 
@@ -112,37 +112,37 @@ linux:julia1.6:
 
 windows8:julia1.5:
   stage: test-compat
-  <<: *global_on_compat_test
+  <<: *global_on_compat_tests
   <<: *global_env_julia15
   <<: *global_env_win8
 
 windows8:julia1.6:
   stage: test-compat
-  <<: *global_on_compat_test
+  <<: *global_on_compat_tests
   <<: *global_env_julia16
   <<: *global_env_win8
 
 windows10:julia1.5:
   stage: test-compat
-  <<: *global_on_compat_test
+  <<: *global_on_compat_tests
   <<: *global_env_julia15
   <<: *global_env_win10
 
 windows10:julia1.6:
   stage: test-compat
-  <<: *global_on_compat_test
+  <<: *global_on_compat_tests
   <<: *global_env_julia16
   <<: *global_env_win10
 
 mac:julia1.5:
   stage: test-compat
-  <<: *global_on_compat_test
+  <<: *global_on_compat_tests
   <<: *global_env_julia15
   <<: *global_env_mac
 
 mac:julia1.6:
   stage: test-compat
-  <<: *global_on_compat_test
+  <<: *global_on_compat_tests
   <<: *global_env_julia16
   <<: *global_env_mac
 
@@ -222,7 +222,7 @@ doc-tests:julia1.6:
   script:
     - julia --project=@. -e 'import Pkg; Pkg.instantiate();'
     - julia --project=@. --color=yes test/doctests.jl
-  <<: *global_on_full_test
+  <<: *global_on_full_tests
 
 #
 # Build and deploy the documentation
@@ -261,4 +261,4 @@ trigger:
     - privileged
   script:
     - curl --silent --output /dev/null -X POST -F token=$EXTERNAL_REPO_TOKEN -F ref=$EXTERNAL_REPO_BRANCH $EXTERNAL_REPO
-  <<: *global_on_full_test
+  <<: *global_on_full_tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -116,22 +116,10 @@ windows8:julia1.5:
   <<: *global_julia15
   <<: *global_env_win8
 
-windows8:julia1.6:
-  stage: test-compat
-  <<: *global_trigger_compat_tests
-  <<: *global_julia16
-  <<: *global_env_win8
-
 windows10:julia1.5:
   stage: test-compat
   <<: *global_trigger_compat_tests
   <<: *global_julia15
-  <<: *global_env_win10
-
-windows10:julia1.6:
-  stage: test-compat
-  <<: *global_trigger_compat_tests
-  <<: *global_julia16
   <<: *global_env_win10
 
 mac:julia1.5:
@@ -139,6 +127,18 @@ mac:julia1.5:
   <<: *global_trigger_compat_tests
   <<: *global_julia15
   <<: *global_env_mac
+
+windows8:julia1.6:
+  stage: test-compat
+  <<: *global_trigger_compat_tests
+  <<: *global_julia16
+  <<: *global_env_win8
+
+windows10:julia1.6:
+  stage: test-compat
+  <<: *global_trigger_compat_tests
+  <<: *global_julia16
+  <<: *global_env_win10
 
 mac:julia1.6:
   stage: test-compat

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,11 +37,11 @@ variables:
 # Test environment & platform settings
 #
 
-.global_env_julia15: &global_env_julia15
+.global_julia15: &global_julia15
   variables:
     JULIA_VER: "v1.5.3"
 
-.global_env_julia16: &global_env_julia16
+.global_julia16: &global_julia16
   variables:
     JULIA_VER: "v1.6.0"
 
@@ -97,13 +97,13 @@ docker:julia1.6:
 linux:julia1.5:
   stage: test
   <<: *global_trigger_full_tests
-  <<: *global_env_julia15
+  <<: *global_julia15
   <<: *global_env_linux
 
 linux:julia1.6:
   stage: test
   <<: *global_trigger_full_tests
-  <<: *global_env_julia16
+  <<: *global_julia16
   <<: *global_env_linux
 
 #
@@ -113,37 +113,37 @@ linux:julia1.6:
 windows8:julia1.5:
   stage: test-compat
   <<: *global_trigger_compat_tests
-  <<: *global_env_julia15
+  <<: *global_julia15
   <<: *global_env_win8
 
 windows8:julia1.6:
   stage: test-compat
   <<: *global_trigger_compat_tests
-  <<: *global_env_julia16
+  <<: *global_julia16
   <<: *global_env_win8
 
 windows10:julia1.5:
   stage: test-compat
   <<: *global_trigger_compat_tests
-  <<: *global_env_julia15
+  <<: *global_julia15
   <<: *global_env_win10
 
 windows10:julia1.6:
   stage: test-compat
   <<: *global_trigger_compat_tests
-  <<: *global_env_julia16
+  <<: *global_julia16
   <<: *global_env_win10
 
 mac:julia1.5:
   stage: test-compat
   <<: *global_trigger_compat_tests
-  <<: *global_env_julia15
+  <<: *global_julia15
   <<: *global_env_mac
 
 mac:julia1.6:
   stage: test-compat
   <<: *global_trigger_compat_tests
-  <<: *global_env_julia16
+  <<: *global_julia16
   <<: *global_env_mac
 
 #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,68 +1,157 @@
+
 stages:
-  - generator
-  - test-basic
-  - test-required
-  - documentation
-  - test-additional-v1.5
-  - test-additional-v1.6
+  - test # this checks the viability of the code
+  - docdata # this builds stuff and assets for the documentation
+  - documentation # this builds and deploys the actual documentation
+  - test-compat # this runs many additional compatibility tests
 
 variables:
-    GIT_STRATEGY: clone
-    DOCKER_DRIVER: overlay2
-    DOCKER_TLS_CERTDIR: ""
+  GIT_STRATEGY: clone
+  DOCKER_DRIVER: overlay2
+  DOCKER_TLS_CERTDIR: ""
 
-.global_settings: &global_settings_pull
+#
+# Predefined conditions for triggering jobs
+#
+
+.global_on_check_incoming_code: &global_on_check_incoming_code
   rules:
-   - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
 
-.global_settings: &global_settings_comprehensive
+.global_on_build_doc: &global_on_build_doc
   rules:
-   - if: $CI_COMMIT_BRANCH == "master"
-   - if: $CI_COMMIT_BRANCH == "develop"
-   - if: $CI_COMMIT_TAG =~ /^v/
+    - if: $CI_COMMIT_BRANCH == "develop"
+    - if: $CI_COMMIT_TAG =~ /^v/
 
-.global_testing_v15: &global_testing_v15
+.global_on_full_test: &global_on_full_tests
+  rules:
+    - if: $CI_COMMIT_BRANCH == "develop"
+    - if: $CI_COMMIT_BRANCH == "master"
+    - if: $CI_COMMIT_TAG =~ /^v/
+
+.global_on_compat_test: &global_on_compat_test
+  rules:
+    - if: $CI_COMMIT_BRANCH == "master"
+
+#
+# Test environment & platform settings
+#
+
+.global_env_julia15: &global_env_julia15
   variables:
     JULIA_VER: "v1.5.3"
 
-.global_testing_v16: &global_testing_v16
+.global_env_julia16: &global_env_julia16
   variables:
     JULIA_VER: "v1.6.0"
 
-# platform-specific test settings
-# --------------------------------------
-
-.global_testing_linux: &global_testing_linux
+.global_env_linux: &global_env_linux
   tags:
-   - slave01
+    - slave01
   script:
     - $ARTENOLIS_SOFT_PATH/julia/$JULIA_VER/bin/julia --inline=yes --check-bounds=yes --color=yes --project=@. -e 'import Pkg; Pkg.test(; coverage = true)'
 
-.global_testing_win8: &global_testing_win8
-  tags:
-    - windows8
-
-.global_testing_win10: &global_testing_win10
-  tags:
-    - windows10
-
-.global_testing_win: &global_testing_win
+.global_env_win: &global_env_win
   script:
     - $global:LASTEXITCODE = 0 # Note the global prefix.
-    - Invoke-Expression $Env:ARTENOLIS_SOFT_PATH"\julia\"$Env:JULIA_VER"\bin\julia --inline=yes --check-bounds=yes --color=yes --project=@. -e 'import Pkg; Pkg.test(; coverage = true)'"
+    - Invoke-Expression $Env:ARTENOLIS_SOFT_PATH"\julia\"$Env:JULIA_VER"\bin\julia" --inline=yes --check-bounds=yes --color=yes --project=@. -e 'import Pkg; Pkg.test(; coverage = true)'
     - exit $LASTEXITCODE
 
-.global_testing_mac: &global_testing_mac
+.global_env_win8: &global_env_win8
+  tags:
+    - windows8
+  <<: *global_env_win
+
+.global_env_win10: &global_env_win10
+  tags:
+    - windows10
+  <<: *global_env_win
+
+.global_env_mac: &global_env_mac
   tags:
     - mac
   script:
     - $ARTENOLIS_SOFT_PATH/julia/$JULIA_VER/Contents/Resources/julia/bin/julia --inline=yes --check-bounds=yes --color=yes --project=@. -e 'import Pkg; Pkg.test(; coverage = true)'
 
-# Check the format of the code
-# --------------------------------------
+#
+# TESTS
+#
+# The "basic" required test that gets triggered for the basic testing, runs in
+# any available docker and current julia
+#
+
+docker:julia1.6:
+  stage: test
+  image: $CI_REGISTRY/r3/docker/julia-custom
+  script:
+    - julia --check-bounds=yes --inline=yes --project=@. -e "import Pkg; Pkg.test(; coverage = true)"
+  after_script:
+    - julia --project=test/coverage test/coverage/coverage-summary.jl
+  <<: *global_on_check_incoming_code
+
+#
+# The required compatibility test to pass on branches&tags before the docs get
+# built & deployed
+#
+
+linux:julia1.5:
+  stage: test
+  <<: *global_on_full_test
+  <<: *global_env_julia15
+  <<: *global_env_linux
+
+linux:julia1.6:
+  stage: test
+  <<: *global_on_full_test
+  <<: *global_env_julia16
+  <<: *global_env_linux
+
+#
+# Additional platform&environment compatibility tests
+#
+
+windows8:julia1.5:
+  stage: test-compat
+  <<: *global_on_compat_test
+  <<: *global_env_julia15
+  <<: *global_env_win8
+
+windows8:julia1.6:
+  stage: test-compat
+  <<: *global_on_compat_test
+  <<: *global_env_julia16
+  <<: *global_env_win8
+
+windows10:julia1.5:
+  stage: test-compat
+  <<: *global_on_compat_test
+  <<: *global_env_julia15
+  <<: *global_env_win10
+
+windows10:julia1.6:
+  stage: test-compat
+  <<: *global_on_compat_test
+  <<: *global_env_julia16
+  <<: *global_env_win10
+
+mac:julia1.5:
+  stage: test-compat
+  <<: *global_on_compat_test
+  <<: *global_env_julia15
+  <<: *global_env_mac
+
+mac:julia1.6:
+  stage: test-compat
+  <<: *global_on_compat_test
+  <<: *global_env_julia16
+  <<: *global_env_mac
+
+#
+# Code format checker for pull-requests
+#
 
 format:
-  stage: test-basic
+  stage: test
   image: docker:19.03.13
   tags:
     - privileged
@@ -100,13 +189,15 @@ format:
             -e GITHUB_COMMENT_FORMAT \
             -e GITHUB_COMMENT \
             cloudposse/github-commenter
-  <<: *global_settings_pull
+  <<: *global_on_check_incoming_code
 
-# Documentation history
-# --------------------------------------
+#
+# Development history gif built with gource
+#
 
-generator:gource:
-  stage: generator
+docdata:gource:
+  stage: docdata
+  needs: [] # allow faster start
   image: docker:19.03.13
   tags:
     - privileged
@@ -119,32 +210,37 @@ generator:gource:
     - docker run -v "$PWD":/visualization $CI_REGISTRY/r3/docker/gource
   artifacts:
     paths: ['output.gif']
-  <<: *global_settings_comprehensive
+  <<: *global_on_build_doc
 
-# Documentation tests
-# --------------------------------------
+#
+# Run documentation tests
+#
 
-doc-tests:v1.6:
-  stage: documentation
+doc-tests:julia1.6:
+  stage: test
   image: $CI_REGISTRY/r3/docker/julia-custom
   script:
     - julia --project=@. -e 'import Pkg; Pkg.instantiate();'
     - julia --project=@. --color=yes test/doctests.jl
-  <<: *global_settings_pull
+  <<: *global_on_full_test
 
-# Deploy the documentation
-# --------------------------------------
+#
+# Build and deploy the documentation
+#
 
 pages:
   stage: documentation
   dependencies:
-    - generator:gource
+    - docdata:gource
+      # Note: This dependency is also implied by the stage ordering, but let's
+      # be sure. As of Nov 2021, the assets are not used directly, but referred
+      # to externally from the docs.
   image: $CI_REGISTRY/r3/docker/julia-custom
   script:
     # resolve and build packages from the docs/Project.toml file
     - julia --project=docs -e 'using Pkg; Pkg.resolve(); Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate();'
 
-    # deploy doc (without git history)
+    # deploy doc (the without git history)
     - julia --project=docs --color=yes docs/make.jl
 
     # move to the directory picked up by Gitlab pages (with git history)
@@ -152,90 +248,17 @@ pages:
   artifacts:
     paths:
       - public
-  <<: *global_settings_comprehensive
+  <<: *global_on_build_doc
 
-# Test Docker run with Julia v1.6
-# --------------------------------------
-
-docker:v1.6:
-  stage: test-basic
-  image: $CI_REGISTRY/r3/docker/julia-custom
-  script:
-    - julia --check-bounds=yes --inline=yes --project=@. -e "import Pkg; Pkg.test(; coverage = true)"
-  after_script:
-    - julia --project=test/coverage test/coverage/coverage-summary.jl
-  <<: *global_settings_pull
-
-# Test Julia v1.5
-# --------------------------------------
-
-linux:v1.5:
-  stage: test-required
-  <<: *global_settings_comprehensive
-  <<: *global_testing_v15
-  <<: *global_testing_linux
-
-windows10:v1.5:
-  stage: test-additional-v1.5
-  <<: *global_settings_comprehensive
-  <<: *global_testing_v15
-  <<: *global_testing_win10
-  <<: *global_testing_win
-
-windows8:v1.5:
-  stage: test-additional-v1.5
-  <<: *global_settings_comprehensive
-  <<: *global_testing_v15
-  <<: *global_testing_win8
-  <<: *global_testing_win
-
-mac:v1.5:
-  stage: test-additional-v1.5
-  <<: *global_settings_comprehensive
-  <<: *global_testing_v15
-  <<: *global_testing_mac
-
-# Test Julia v1.6
-# --------------------------------------
-
-linux:v1.6:
-  stage: test-additional-v1.6
-  needs: ["linux:v1.5"]
-  <<: *global_settings_comprehensive
-  <<: *global_testing_v16
-  <<: *global_testing_linux
-
-windows10:v1.6:
-  stage: test-additional-v1.6
-  needs: ["windows10:v1.5"]
-  <<: *global_settings_comprehensive
-  <<: *global_testing_v16
-  <<: *global_testing_win10
-  <<: *global_testing_win
-
-windows8:v1.6:
-  stage: test-additional-v1.6
-  needs: ["windows8:v1.5"]
-  <<: *global_settings_comprehensive
-  <<: *global_testing_v16
-  <<: *global_testing_win8
-  <<: *global_testing_win
-
-mac:v1.6:
-  stage: test-additional-v1.6
-  needs: ["mac:v1.5"]
-  <<: *global_settings_comprehensive
-  <<: *global_testing_v16
-  <<: *global_testing_mac
-
-# Trigger test pipelines in external repo
-# --------------------------------------
+#
+# Trigger the test pipeline in external repo
+#
 
 trigger:
-  stage: test-required
+  stage: test
   image: curlimages/curl
   tags:
     - privileged
   script:
     - curl --silent --output /dev/null -X POST -F token=$EXTERNAL_REPO_TOKEN -F ref=$EXTERNAL_REPO_BRANCH $EXTERNAL_REPO
-  <<: *global_settings_comprehensive
+  <<: *global_on_full_test

--- a/docs/src/index.md.template
+++ b/docs/src/index.md.template
@@ -32,7 +32,7 @@ the popular [`Tulip.jl`](https://github.com/ds4dm/Tulip.jl),
 
 ```@raw html
 <div align="center">
-<img style="width:300px;margin:10px;border-offset:15px;border: 1px solid #eee;border-radius: 50%;padding: 10px;-webkit-border-radius: 50%;-moz-border-radius: 50%;" src="https://git-r3lab.uni.lu/lcsb-biocore/COBREXA.jl/-/jobs/artifacts/master/raw/output.gif?job=documentation-assets:gource" alt="history"><br>
+<img style="width:300px;margin:10px;border-offset:15px;border: 1px solid #eee;border-radius: 50%;padding: 10px;-webkit-border-radius: 50%;-moz-border-radius: 50%;" src="https://gitlab.lcsb.uni.lu/lcsb-biocore/COBREXA.jl/-/jobs/artifacts/master/raw/output.gif?job=documentation-assets:gource" alt="history"><br>
 Development history of COBREXA.jl.
 </div>
 ```

--- a/docs/src/index.md.template
+++ b/docs/src/index.md.template
@@ -32,7 +32,7 @@ the popular [`Tulip.jl`](https://github.com/ds4dm/Tulip.jl),
 
 ```@raw html
 <div align="center">
-<img style="width:300px;margin:10px;border-offset:15px;border: 1px solid #eee;border-radius: 50%;padding: 10px;-webkit-border-radius: 50%;-moz-border-radius: 50%;" src="https://git-r3lab.uni.lu/lcsb-biocore/COBREXA.jl/-/jobs/artifacts/master/raw/output.gif?job=generator:gource" alt="history"><br>
+<img style="width:300px;margin:10px;border-offset:15px;border: 1px solid #eee;border-radius: 50%;padding: 10px;-webkit-border-radius: 50%;-moz-border-radius: 50%;" src="https://git-r3lab.uni.lu/lcsb-biocore/COBREXA.jl/-/jobs/artifacts/master/raw/output.gif?job=docdata:gource" alt="history"><br>
 Development history of COBREXA.jl.
 </div>
 ```

--- a/docs/src/index.md.template
+++ b/docs/src/index.md.template
@@ -32,7 +32,7 @@ the popular [`Tulip.jl`](https://github.com/ds4dm/Tulip.jl),
 
 ```@raw html
 <div align="center">
-<img style="width:300px;margin:10px;border-offset:15px;border: 1px solid #eee;border-radius: 50%;padding: 10px;-webkit-border-radius: 50%;-moz-border-radius: 50%;" src="https://git-r3lab.uni.lu/lcsb-biocore/COBREXA.jl/-/jobs/artifacts/master/raw/output.gif?job=docdata:gource" alt="history"><br>
+<img style="width:300px;margin:10px;border-offset:15px;border: 1px solid #eee;border-radius: 50%;padding: 10px;-webkit-border-radius: 50%;-moz-border-radius: 50%;" src="https://git-r3lab.uni.lu/lcsb-biocore/COBREXA.jl/-/jobs/artifacts/master/raw/output.gif?job=documentation-assets:gource" alt="history"><br>
 Development history of COBREXA.jl.
 </div>
 ```


### PR DESCRIPTION
This introduces a lot of changes:

- required & fast tests for branches vs. PRs are in a single stage but picked dynamicaly
- branch&tag builds test both 1.5 and 1.6 julia on linux
- compatibility tests are squashed into one big heap (the probability of something failing when the "main" tests passed is generally low, thus the savings from the extra dependencies are negligible)
- the trigger rules are reorganized to "scenarios"
- stuff is now slightly renamed to look nicer

Externally from CI, the gource gif is now tagged not with `generator:` but `docdata:` which sounds a bit more semantic to me.

The diff is a mess, better re-read the whole yml again-- hopefully the commends & renaming will make that easier.