### PR TITLE
do not run PR + branch checks together

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,10 +16,16 @@ variables:
 
 .global_trigger_pull_request: &global_trigger_pull_request
   rules:
+    - if: $CI_COMMIT_BRANCH == "develop"
+      when: never
+    - if: $CI_COMMIT_BRANCH == "master"
+      when: never
     - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
 
 .global_trigger_build_doc: &global_trigger_build_doc
   rules:
+    - if: $CI_PIPELINE_SOURCE == "external_pull_request_event"
+      when: never
     - if: $CI_COMMIT_BRANCH == "develop"
     - if: $CI_COMMIT_TAG =~ /^v/
 


### PR DESCRIPTION
This avoids builds where everything gets triggered at once, like this one:
https://gitlab.lcsb.uni.lu/lcsb-biocore/COBREXA.jl/-/pipelines/49217
