### PR TITLE
Simplify tests that use OSQP

### DIFF
--- a/docs/src/notebooks/2_finding_balance.jl
+++ b/docs/src/notebooks/2_finding_balance.jl
@@ -155,6 +155,8 @@ dict_soln = parsimonious_flux_balance_analysis_dict(
     modifications = [
         silence, # silence the optimizer (OSQP is very verbose by default)
         change_constraint("R_EX_glc__D_e"; lb = -12, ub = -12),
+        change_optimizer_attribute("polish", true),
+        change_optimizer_attribute("max-iter", 10_000),
     ],
 )
 
@@ -176,6 +178,7 @@ vec_soln = parsimonious_flux_balance_analysis_vec(
     qp_modifications = [
         change_optimizer(OSQP.Optimizer), # now switch to OSQP (Tulip wouldn't be able to finish the computation)
         change_optimizer_attribute("polish", true), # get an accurate solution, see OSQP's documentation
+        change_optimizer_attribute("max-iter", 10_000),
         silence, # and make it quiet.
     ],
 )
@@ -188,7 +191,11 @@ vec_soln = parsimonious_flux_balance_analysis_vec(
 reference_fluxes = parsimonious_flux_balance_analysis_dict( # reference distribution
     model,
     OSQP.Optimizer;
-    modifications = [silence, change_optimizer_attribute("polish", true)],
+    modifications = [
+        silence,
+        change_optimizer_attribute("polish", true),
+        change_optimizer_attribute("max-iter", 10_000),
+    ],
 )
 
 moma = minimize_metabolic_adjustment_analysis_dict(
@@ -198,6 +205,7 @@ moma = minimize_metabolic_adjustment_analysis_dict(
     modifications = [
         silence,
         change_optimizer_attribute("polish", true),
+        change_optimizer_attribute("max-iter", 10_000),
         change_constraint("R_CYTBD"; lb = 0.0, ub = 0.0), # find flux distribution closest to the CYTBD knockout
     ],
 )
@@ -248,6 +256,7 @@ moment_moma = minimize_metabolic_adjustment_analysis_dict(
     modifications = [
         silence,
         change_optimizer_attribute("polish", true),
+        change_optimizer_attribute("max-iter", 10_000),
         change_constraint("EX_glc__D_e", lb = -1000),
         change_constraint("CYTBD"; lb = 0, ub = 0),
         add_moment_constraints(ksas, protein_mass_fraction;),

--- a/docs/src/notebooks/2_finding_balance.jl
+++ b/docs/src/notebooks/2_finding_balance.jl
@@ -156,7 +156,6 @@ dict_soln = parsimonious_flux_balance_analysis_dict(
         silence, # silence the optimizer (OSQP is very verbose by default)
         change_constraint("R_EX_glc__D_e"; lb = -12, ub = -12),
         change_optimizer_attribute("polish", true),
-        change_optimizer_attribute("max-iter", 10_000),
     ],
 )
 
@@ -178,7 +177,6 @@ vec_soln = parsimonious_flux_balance_analysis_vec(
     qp_modifications = [
         change_optimizer(OSQP.Optimizer), # now switch to OSQP (Tulip wouldn't be able to finish the computation)
         change_optimizer_attribute("polish", true), # get an accurate solution, see OSQP's documentation
-        change_optimizer_attribute("max-iter", 10_000),
         silence, # and make it quiet.
     ],
 )
@@ -194,7 +192,6 @@ reference_fluxes = parsimonious_flux_balance_analysis_dict( # reference distribu
     modifications = [
         silence,
         change_optimizer_attribute("polish", true),
-        change_optimizer_attribute("max-iter", 10_000),
     ],
 )
 
@@ -205,7 +202,6 @@ moma = minimize_metabolic_adjustment_analysis_dict(
     modifications = [
         silence,
         change_optimizer_attribute("polish", true),
-        change_optimizer_attribute("max-iter", 10_000),
         change_constraint("R_CYTBD"; lb = 0.0, ub = 0.0), # find flux distribution closest to the CYTBD knockout
     ],
 )

--- a/docs/src/notebooks/2_finding_balance.jl
+++ b/docs/src/notebooks/2_finding_balance.jl
@@ -189,10 +189,7 @@ vec_soln = parsimonious_flux_balance_analysis_vec(
 reference_fluxes = parsimonious_flux_balance_analysis_dict( # reference distribution
     model,
     OSQP.Optimizer;
-    modifications = [
-        silence,
-        change_optimizer_attribute("polish", true),
-    ],
+    modifications = [silence, change_optimizer_attribute("polish", true)],
 )
 
 moma = minimize_metabolic_adjustment_analysis_dict(

--- a/test/analysis/minimize_metabolic_adjustment.jl
+++ b/test/analysis/minimize_metabolic_adjustment.jl
@@ -10,7 +10,6 @@
         modifications = [
             silence,
             change_optimizer_attribute("polish", true),
-            change_optimizer_attribute("max-iter", 100_000),
         ],
     )
 

--- a/test/analysis/minimize_metabolic_adjustment.jl
+++ b/test/analysis/minimize_metabolic_adjustment.jl
@@ -7,15 +7,8 @@
         model,
         sol,
         OSQP.Optimizer;
-        modifications = [
-            silence,
-            change_optimizer_attribute("polish", true),
-        ],
+        modifications = [silence, change_optimizer_attribute("polish", true)],
     )
 
-    @test isapprox(
-        moma["biomass1"],
-        0.07692307692307691,
-        atol = QP_TEST_TOLERANCE,
-    )
+    @test isapprox(moma["biomass1"], 0.07692307692307691, atol = QP_TEST_TOLERANCE)
 end

--- a/test/analysis/minimize_metabolic_adjustment.jl
+++ b/test/analysis/minimize_metabolic_adjustment.jl
@@ -1,11 +1,7 @@
 @testset "MOMA" begin
-    model = load_model(StandardModel, model_paths["e_coli_core.json"])
+    model = test_toyModel()
 
-    sol = parsimonious_flux_balance_analysis_dict(
-        model,
-        OSQP.Optimizer;
-        modifications = [silence, change_optimizer_attribute("polish", true)],
-    )
+    sol = [looks_like_biomass_reaction(rid) ? 0.5 : 0.0 for rid in reactions(model)]
 
     moma = minimize_metabolic_adjustment_analysis_dict(
         model,
@@ -14,13 +10,13 @@
         modifications = [
             silence,
             change_optimizer_attribute("polish", true),
-            change_constraint("CYTBD"; lb = 0.0, ub = 0.0),
+            change_optimizer_attribute("max-iter", 100_000),
         ],
     )
 
     @test isapprox(
-        moma["BIOMASS_Ecoli_core_w_GAM"],
-        0.06214149238730545,
+        moma["biomass1"],
+        0.07692307692307691,
         atol = QP_TEST_TOLERANCE,
     )
 end

--- a/test/analysis/parsimonious_flux_balance_analysis.jl
+++ b/test/analysis/parsimonious_flux_balance_analysis.jl
@@ -1,10 +1,11 @@
 @testset "Parsimonious flux balance analysis with StandardModel" begin
-    model = load_model(StandardModel, model_paths["e_coli_core.json"])
+    model = test_toyModel()
+
     d = parsimonious_flux_balance_analysis_dict(
         model,
         Tulip.Optimizer;
         modifications = [
-            change_constraint("EX_glc__D_e"; lb = -12, ub = -12),
+            change_constraint("EX_m1(e)", lb=-10.0),
             change_optimizer_attribute("IPM_IterationsLimit", 500),
         ],
         qp_modifications = [
@@ -17,5 +18,5 @@
 
     # The used optimizer doesn't really converge to the same answer everytime
     # here, we therefore tolerate a wide range of results.
-    @test isapprox(d["PGM"], -17.606459419216442, atol = QP_TEST_TOLERANCE)
+    @test isapprox(d["biomass1"], 10.0, atol = QP_TEST_TOLERANCE)
 end

--- a/test/analysis/parsimonious_flux_balance_analysis.jl
+++ b/test/analysis/parsimonious_flux_balance_analysis.jl
@@ -10,19 +10,7 @@
         qp_modifications = [
             change_optimizer(OSQP.Optimizer),
             change_optimizer_attribute("polish", true),
-            silence,
-        ],
-    )
-    v = parsimonious_flux_balance_analysis_vec(
-        model,
-        Tulip.Optimizer;
-        modifications = [
-            change_constraint("EX_glc__D_e"; lb = -12, ub = -12),
-            change_optimizer_attribute("IPM_IterationsLimit", 500),
-        ],
-        qp_modifications = [
-            change_optimizer(OSQP.Optimizer),
-            change_optimizer_attribute("polish", true),
+            change_optimizer_attribute("max-iter", 10_000),
             silence,
         ],
     )
@@ -30,5 +18,4 @@
     # The used optimizer doesn't really converge to the same answer everytime
     # here, we therefore tolerate a wide range of results.
     @test isapprox(d["PGM"], -17.606459419216442, atol = QP_TEST_TOLERANCE)
-    @test isapprox(v[8], -17.606459419216442, atol = QP_TEST_TOLERANCE)
 end

--- a/test/analysis/parsimonious_flux_balance_analysis.jl
+++ b/test/analysis/parsimonious_flux_balance_analysis.jl
@@ -11,7 +11,6 @@
         qp_modifications = [
             change_optimizer(OSQP.Optimizer),
             change_optimizer_attribute("polish", true),
-            change_optimizer_attribute("max-iter", 10_000),
             silence,
         ],
     )

--- a/test/analysis/parsimonious_flux_balance_analysis.jl
+++ b/test/analysis/parsimonious_flux_balance_analysis.jl
@@ -5,7 +5,7 @@
         model,
         Tulip.Optimizer;
         modifications = [
-            change_constraint("EX_m1(e)", lb=-10.0),
+            change_constraint("EX_m1(e)", lb = -10.0),
             change_optimizer_attribute("IPM_IterationsLimit", 500),
         ],
         qp_modifications = [


### PR DESCRIPTION
OSQP fails sometimes due to convergence issues from starting points that are too far out of bounds (probably). Alleviate this issue by increasing the iteration limit and using simpler models where possible.