### PR TITLE
Revert "display banner consistently at each import"

### DIFF
--- a/src/COBREXA.jl
+++ b/src/COBREXA.jl
@@ -19,11 +19,9 @@ import Base: findfirst, getindex, show
 import Pkg
 import SBML # conflict with Reaction struct name
 
-include("banner.jl")
 
-function __init__()
-    _print_banner()
-end
+include("banner.jl")
+_print_banner()
 
 # autoloading
 const _inc(path...) = include(joinpath(path...))


### PR DESCRIPTION
This reverts commit 71cc7c8f7a9d823abf9790c3100103b5d55285bc.

Apparently (from slack conversation) it is displayed too often, esp. in distributed workflows. Search for a good middle way continues.
