### PR TITLE
Improve `remove_XXX` functions

### DIFF
--- a/src/reconstruction/CoreModel.jl
+++ b/src/reconstruction/CoreModel.jl
@@ -363,7 +363,7 @@ end
     model.xl = model.xl[mask]
     model.xu = model.xu[mask]
     model.rxns = model.rxns[mask]
-    return nothing
+    nothing
 end
 
 @_remove_fn reaction CoreModel Int begin
@@ -408,7 +408,7 @@ end
     model.S = model.S[mask, :]
     model.b = model.b[mask]
     model.mets = model.mets[mask]
-    return nothing
+    nothing
 end
 
 @_remove_fn metabolite CoreModel Int begin

--- a/src/reconstruction/CoreModelCoupled.jl
+++ b/src/reconstruction/CoreModelCoupled.jl
@@ -205,7 +205,6 @@ function add_coupling_constraints!(
     return add_coupling_constraints!(m, sparse(reshape(c, (1, length(c)))), [cl], [cu])
 end
 
-
 """
     add_coupling_constraints!(
         m::CoreModelCoupled,
@@ -234,8 +233,8 @@ function add_coupling_constraints!(
     m.C = vcat(m.C, sparse(C))
     m.cl = vcat(m.cl, collect(cl))
     m.cu = vcat(m.cu, collect(cu))
+    nothing
 end
-
 
 """
     remove_coupling_constraints(m::CoreModelCoupled, args...)
@@ -249,7 +248,6 @@ function remove_coupling_constraints(m::CoreModelCoupled, args...)
     remove_coupling_constraints!(new_model, args...)
     return new_model
 end
-
 
 """
     remove_coupling_constraints!(m::CoreModelCoupled, constraint::Int)
@@ -272,8 +270,8 @@ function remove_coupling_constraints!(m::CoreModelCoupled, constraints::Vector{I
     m.C = m.C[to_be_kept, :]
     m.cl = m.cl[to_be_kept]
     m.cu = m.cu[to_be_kept]
+    nothing
 end
-
 
 """
     change_coupling_bounds!(
@@ -308,6 +306,7 @@ function change_coupling_bounds!(
             throw(DimensionMismatch("`constraints` size doesn't match with `cu`"))
         model.cu[red_constraints] = cu[found]
     end
+    nothing
 end
 
 @_change_bounds_fn CoreModelCoupled Int inplace begin
@@ -358,7 +357,7 @@ end
     orig_rxns = reactions(model.lm)
     remove_reactions!(model.lm, reaction_idxs)
     model.C = model.C[:, in.(orig_rxns, Ref(Set(reactions(model.lm))))]
-    return nothing
+    nothing
 end
 
 @_remove_fn reaction CoreModelCoupled Int begin
@@ -396,7 +395,7 @@ end
     orig_rxns = reactions(model.lm)
     model.lm = remove_metabolites(model.lm, metabolite_idxs)
     model.C = model.C[:, in.(orig_rxns, Ref(Set(reactions(model.lm))))]
-    return nothing
+    nothing
 end
 
 @_remove_fn metabolite CoreModelCoupled Int begin

--- a/src/reconstruction/StandardModel.jl
+++ b/src/reconstruction/StandardModel.jl
@@ -7,6 +7,7 @@ function add_reactions!(model::StandardModel, rxns::Vector{Reaction})
     for rxn in rxns
         model.reactions[rxn.id] = rxn
     end
+    nothing
 end
 
 """
@@ -25,6 +26,7 @@ function add_metabolites!(model::StandardModel, mets::Vector{Metabolite})
     for met in mets
         model.metabolites[met.id] = met
     end
+    nothing
 end
 
 """
@@ -43,6 +45,7 @@ function add_genes!(model::StandardModel, genes::Vector{Gene})
     for gene in genes
         model.genes[gene.id] = gene
     end
+    nothing
 end
 
 """
@@ -137,6 +140,7 @@ function remove_genes!(
         pop!.(Ref(model.reactions), rm_reactions)
     end
     pop!.(Ref(model.genes), gids)
+    nothing
 end
 
 """
@@ -161,7 +165,7 @@ remove_gene!(model::StandardModel, gid::String; knockout_reactions::Bool = false
 @_change_bounds_fn StandardModel String inplace begin
     isnothing(lower) || (model.reactions[rxn_id].lb = lower)
     isnothing(upper) || (model.reactions[rxn_id].ub = upper)
-    return nothing
+    nothing
 end
 
 @_change_bounds_fn StandardModel String inplace plural begin
@@ -185,11 +189,17 @@ end
 end
 
 @_remove_fn reaction StandardModel String inplace begin
-    delete!(model.reactions, reaction_id)
+    if !(reaction_id in reactions(model))
+        @_models_log @info "Reaction $reaction_id not found in model."
+    else
+        delete!(model.reactions, reaction_id)
+    end
+    nothing
 end
 
 @_remove_fn reaction StandardModel String inplace plural begin
     remove_reaction!.(Ref(model), reaction_ids)
+    nothing
 end
 
 @_remove_fn reaction StandardModel String begin
@@ -204,19 +214,17 @@ end
 end
 
 @_remove_fn metabolite StandardModel String inplace begin
-    remove_metabolites!(model, [metabolite_id])
+    if !(metabolite_id in metabolites(model))
+        @_models_log @info "Metabolite $metabolite_id not found in model."
+    else
+        delete!(model.metabolites, metabolite_id)
+    end
+    nothing
 end
 
 @_remove_fn metabolite StandardModel String inplace plural begin
-    remove_reactions!(
-        model,
-        [
-            rid for (rid, rn) in model.reactions if
-            any(haskey.(Ref(rn.metabolites), metabolite_ids))
-        ],
-    )
-    delete!.(Ref(model.metabolites), metabolite_ids)
-    return nothing
+    remove_metabolite!.(Ref(model), metabolite_ids)
+    nothing
 end
 
 @_remove_fn metabolite StandardModel String begin


### PR DESCRIPTION
Changes:
1) `remove_XXX!` should return `nothing`  - ugly data structures get returned when working at the repl
2) ~`remove_XXX` does not check or maintain consistency anymore, this is up to the user to know what they are doing when they delete a reaction.~
3) ~`remove_XXX` for standard model does NOT check for consistency, but for core model it does and silently fixes things. I think this is not great due to the surprise factor.. but we will need to discuss this more~