### PR TITLE
Gene-reaction rules for CoreModel and CoreModelCoupled #439

### DIFF
--- a/src/base/types/CoreModel.jl
+++ b/src/base/types/CoreModel.jl
@@ -28,8 +28,10 @@ mutable struct CoreModel <: MetabolicModel
         xu::VecType,
         rxns::StringVecType,
         mets::StringVecType,
-        grrs::Vector{Maybe{GeneAssociation}} =
-            Vector{Maybe{GeneAssociation}}(nothing, length(rxns))
+        grrs::Vector{Maybe{GeneAssociation}} = Vector{Maybe{GeneAssociation}}(
+            nothing,
+            length(rxns),
+        ),
     )
         all([length(b), length(mets)] .== size(S, 1)) ||
             throw(DimensionMismatch("inconsistent number of metabolites"))

--- a/src/base/types/CoreModel.jl
+++ b/src/base/types/CoreModel.jl
@@ -137,7 +137,7 @@ reaction_stoichiometry(m::CoreModel, ridx)::Dict{String,Float64} =
 """
     grrs(a::CoreModel)::Vector{Maybe{GeneAssociation}}
 
-Get the gene associations in a `CoreModel`.
+Get the gene associations in a [`CoreModel`](@ref).
 """
 grrs(a::CoreModel)::Vector{Maybe{GeneAssociation}} = a.grrs
 

--- a/src/base/types/CoreModel.jl
+++ b/src/base/types/CoreModel.jl
@@ -28,7 +28,8 @@ mutable struct CoreModel <: MetabolicModel
         xu::VecType,
         rxns::StringVecType,
         mets::StringVecType,
-        grrs::Vector{Maybe{GeneAssociation}},
+        grrs::Vector{Maybe{GeneAssociation}} =
+            Vector{Maybe{GeneAssociation}}(nothing, length(rxns))
     )
         all([length(b), length(mets)] .== size(S, 1)) ||
             throw(DimensionMismatch("inconsistent number of metabolites"))
@@ -39,42 +40,6 @@ mutable struct CoreModel <: MetabolicModel
 
         new(sparse(S), sparse(b), sparse(c), collect(xl), collect(xu), rxns, mets, grrs)
     end
-end
-
-"""
-    CoreModel(
-        S::MatType,
-        b::VecType,
-        c::VecType,
-        xl::VecType,
-        xu::VecType,
-        rxns::StringVecType,
-        mets::StringVecType
-    )
-
-Create a `CoreModel` without specifying gene-reaction associations.
-"""
-function CoreModel(
-    S::MatType,
-    b::VecType,
-    c::VecType,
-    xl::VecType,
-    xu::VecType,
-    rxns::StringVecType,
-    mets::StringVecType,
-)
-
-    CoreModel(
-        S,
-        b,
-        c,
-        xl,
-        xu,
-        rxns,
-        mets,
-        Vector{Maybe{GeneAssociation}}(nothing, length(rxns)),
-    )
-
 end
 
 """

--- a/src/base/types/CoreModel.jl
+++ b/src/base/types/CoreModel.jl
@@ -160,6 +160,8 @@ function Base.convert(::Type{CoreModel}, m::M) where {M<:MetabolicModel}
         xu,
         reactions(m),
         metabolites(m),
-        [reaction_gene_association(m,id) for id in reactions(m)]
+        Vector{Maybe{GeneAssociation}}(
+            [reaction_gene_association(m,id) for id in reactions(m)]
+        )
     )
 end

--- a/src/base/types/CoreModel.jl
+++ b/src/base/types/CoreModel.jl
@@ -142,6 +142,23 @@ Get the gene associations in a `CoreModel`.
 grrs(a::CoreModel)::Vector{Maybe{GeneAssociation}} = a.grrs
 
 """
+    reaction_gene_association(model::CoreModel, ridx::Int)::Maybe{GeneAssociation}
+
+Retrieve the [`GeneAssociation`](@ref) from [`CoreModel`](@ref) by reaction
+index.
+"""
+reaction_gene_association(model::CoreModel, ridx::Int)::Maybe{GeneAssociation} =
+    model.grrs[ridx]
+
+"""
+    reaction_gene_association(model::CoreModel, rid::String)::Maybe{GeneAssociation}
+
+Retrieve the [`GeneAssociation`](@ref) from [`CoreModel`](@ref) by reaction ID.
+"""
+reaction_gene_association(model::CoreModel, rid::String)::Maybe{GeneAssociation} =
+    model.grrs[first(indexin([rid], model.rxns))]
+
+"""
     Base.convert(::Type{CoreModel}, m::M) where {M <: MetabolicModel}
 
 Make a `CoreModel` out of any compatible model type.

--- a/src/base/types/CoreModel.jl
+++ b/src/base/types/CoreModel.jl
@@ -28,24 +28,16 @@ mutable struct CoreModel <: MetabolicModel
         xu::VecType,
         rxns::StringVecType,
         mets::StringVecType,
-        grrs::Vector{Maybe{GeneAssociation}}
+        grrs::Vector{Maybe{GeneAssociation}},
     )
         all([length(b), length(mets)] .== size(S, 1)) ||
             throw(DimensionMismatch("inconsistent number of metabolites"))
 
-        all([length(c), length(xl), length(xu), length(rxns), length(grrs)] .== size(S, 2)) ||
-            throw(DimensionMismatch("inconsistent number of reactions"))
+        all(
+            [length(c), length(xl), length(xu), length(rxns), length(grrs)] .== size(S, 2),
+        ) || throw(DimensionMismatch("inconsistent number of reactions"))
 
-        new(
-            sparse(S),
-            sparse(b),
-            sparse(c),
-            collect(xl),
-            collect(xu),
-            rxns,
-            mets,
-            grrs
-        )
+        new(sparse(S), sparse(b), sparse(c), collect(xl), collect(xu), rxns, mets, grrs)
     end
 end
 
@@ -69,10 +61,19 @@ function CoreModel(
     xl::VecType,
     xu::VecType,
     rxns::StringVecType,
-    mets::StringVecType
+    mets::StringVecType,
 )
 
-    CoreModel(S, b, c,xl,xu,rxns,mets,Vector{Maybe{GeneAssociation}}(nothing,length(rxns)))
+    CoreModel(
+        S,
+        b,
+        c,
+        xl,
+        xu,
+        rxns,
+        mets,
+        Vector{Maybe{GeneAssociation}}(nothing, length(rxns)),
+    )
 
 end
 
@@ -177,8 +178,8 @@ function Base.convert(::Type{CoreModel}, m::M) where {M<:MetabolicModel}
         xu,
         reactions(m),
         metabolites(m),
-        Vector{Maybe{GeneAssociation}}(
-            [reaction_gene_association(m,id) for id in reactions(m)]
-        )
+        Vector{Maybe{GeneAssociation}}([
+            reaction_gene_association(m, id) for id in reactions(m)
+        ]),
     )
 end

--- a/src/base/types/CoreModelCoupled.jl
+++ b/src/base/types/CoreModelCoupled.jl
@@ -109,6 +109,30 @@ function reaction_stoichiometry(m::CoreModelCoupled, ridx)::Dict{String,Float64}
 end
 
 """
+    grrs(a::CoreModelCoupled)::Vector{Maybe{GeneAssociation}}
+
+Get the gene associations in a [`CoreModelCoupled`](@ref).
+"""
+grrs(a::CoreModelCoupled)::Vector{Maybe{GeneAssociation}} = a.lm.grrs
+
+"""
+    reaction_gene_association(model::CoreModelCoupled, ridx::Int)::Maybe{GeneAssociation}
+
+Retrieve the [`GeneAssociation`](@ref) from [`CoreModelCoupled`](@ref) by reaction
+index.
+"""
+reaction_gene_association(model::CoreModelCoupled, ridx::Int)::Maybe{GeneAssociation} =
+    reaction_gene_association(model.lm, ridx)
+
+"""
+    reaction_gene_association(model::CoreModelCoupled, rid::String)::Maybe{GeneAssociation}
+
+Retrieve the [`GeneAssociation`](@ref) from [`CoreModelCoupled`](@ref) by reaction ID.
+"""
+reaction_gene_association(model::CoreModelCoupled, rid::String)::Maybe{GeneAssociation} =
+    reaction_gene_association(model.lm, rid)
+
+"""
     Base.convert(::Type{CoreModelCoupled}, mm::MetabolicModel)
 
 Make a `CoreModelCoupled` out of any compatible model type.

--- a/test/base/types/CoreModel.jl
+++ b/test/base/types/CoreModel.jl
@@ -13,4 +13,7 @@ end
 
     @test Set(reactions(cm)) == Set(reactions(sm))
     @test Set(reactions(cm)) == Set(reactions(cm2))
+
+    @test reaction_gene_association(sm,reactions(sm)[1]) ==
+        reaction_gene_association(cm,reactions(sm)[1])
 end

--- a/test/base/types/CoreModel.jl
+++ b/test/base/types/CoreModel.jl
@@ -14,6 +14,6 @@ end
     @test Set(reactions(cm)) == Set(reactions(sm))
     @test Set(reactions(cm)) == Set(reactions(cm2))
 
-    @test reaction_gene_association(sm,reactions(sm)[1]) ==
-        reaction_gene_association(cm,reactions(sm)[1])
+    @test reaction_gene_association(sm, reactions(sm)[1]) ==
+          reaction_gene_association(cm, reactions(sm)[1])
 end

--- a/test/base/types/CoreModel.jl
+++ b/test/base/types/CoreModel.jl
@@ -4,3 +4,13 @@
     @test reaction_stoichiometry(model, "EX_ac_e") == Dict("ac_e" => -1)
     @test reaction_stoichiometry(model, 44) == Dict("ac_e" => -1)
 end
+
+@testset "Conversion from and to StandardModel" begin
+    cm = load_model(CoreModel, model_paths["e_coli_core.mat"])
+
+    sm = convert(StandardModel, cm)
+    cm2 = convert(CoreModel, sm)
+
+    @test Set(reactions(cm)) == Set(reactions(sm))
+    @test Set(reactions(cm)) == Set(reactions(cm2))
+end

--- a/test/base/types/CoreModelCoupled.jl
+++ b/test/base/types/CoreModelCoupled.jl
@@ -5,3 +5,16 @@
     @test reaction_stoichiometry(model, 44) == Dict("ac_e" => -1)
 
 end
+
+@testset "Conversion from and to StandardModel" begin
+    cm = load_model(CoreModelCoupled, model_paths["e_coli_core.mat"])
+
+    sm = convert(StandardModel, cm)
+    cm2 = convert(CoreModelCoupled, sm)
+
+    @test Set(reactions(cm)) == Set(reactions(sm))
+    @test Set(reactions(cm)) == Set(reactions(cm2))
+
+    @test reaction_gene_association(sm,reactions(sm)[1]) ==
+        reaction_gene_association(cm,reactions(sm)[1])
+end

--- a/test/base/types/CoreModelCoupled.jl
+++ b/test/base/types/CoreModelCoupled.jl
@@ -15,6 +15,6 @@ end
     @test Set(reactions(cm)) == Set(reactions(sm))
     @test Set(reactions(cm)) == Set(reactions(cm2))
 
-    @test reaction_gene_association(sm,reactions(sm)[1]) ==
-        reaction_gene_association(cm,reactions(sm)[1])
+    @test reaction_gene_association(sm, reactions(sm)[1]) ==
+          reaction_gene_association(cm, reactions(sm)[1])
 end


### PR DESCRIPTION
Introduces the bare minimum for `CoreModel` and `CoreModelCoupled` to have reaction-gene associations. Not sure if genes should be included separately as well.

- [x] All code is formatted with
  [JuliaFormatter](https://github.com/domluna/JuliaFormatter.jl)
  (run `using JuliaFormatter; format("path/to/COBREXA.jl");`)
- [x] Tests work (try with `]test COBREXA`)
- [1/2] All new functions have proper docstrings
- [?] Documentation builds correctly (try with `cd docs; julia make.jl`)
