### PR TITLE
bump up the "history gif" artifact expiration to 3 months

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -221,6 +221,7 @@ documentation-assets:gource:
     - docker run -v "$PWD":/visualization $CI_REGISTRY/r3/docker/gource
   artifacts:
     paths: ['output.gif']
+    expire_in: 3 mos
   <<: *global_trigger_build_doc
 
 #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -221,7 +221,7 @@ documentation-assets:gource:
     - docker run -v "$PWD":/visualization $CI_REGISTRY/r3/docker/gource
   artifacts:
     paths: ['output.gif']
-    expire_in: 3 mos
+    expire_in: 1 year
   <<: *global_trigger_build_doc
 
 #


### PR DESCRIPTION
Now that we don't refresh master that often, the default expire rule leaves us
without the history animation most of the time. This should add a bit of the
bumper space.