### PR TITLE
postpone JuMP 0.22 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 DistributedData = "0.1.4"
 JSON = "0.21"
-JuMP = "0.21, 0.22"
+JuMP = "0.21"
 MAT = "0.10"
 MacroTools = "0.5.6"
 OSQP = "0.6"


### PR DESCRIPTION
This would break most of the tutorials and notebooks before Tulip issue #112 is
addressed (see https://github.com/ds4dm/Tulip.jl/issues/112).

