### PR TITLE
GRR IDs may contain underscores

### DIFF
--- a/src/base/utils/gene_associations.jl
+++ b/src/base/utils/gene_associations.jl
@@ -62,7 +62,7 @@ function _parse_grr_to_sbml(str::String)::Maybe{SBML.GeneProductAssociation}
     toks = String[]
     m = Nothing
     while !isnothing(begin
-        m = match(r"( +|[a-zA-Z0-9]+|[^ a-zA-Z0-9()]+|[(]|[)])(.*)", s)
+        m = match(r"( +|[a-zA-Z0-9_]+|[^ a-zA-Z0-9_()]+|[(]|[)])(.*)", s)
     end)
         tok = strip(m.captures[1])
         !isempty(tok) && push!(toks, tok)

--- a/test/data_downloaded.jl
+++ b/test/data_downloaded.jl
@@ -63,4 +63,9 @@ model_paths = Dict{String,String}(
         df("iJR904.mat"),
         "d17be86293d4caafc32b829da4e2d0d76eb45e1bb837e0138327043a83e20c6e",
     ),
+    "Recon3D.json" => download_data_file(
+        "http://bigg.ucsd.edu/static/models/Recon3D.json",
+        df("Recon3D.json"),
+        "aba925f17547a42f9fdb4c1f685d89364cbf4979bbe7862e9f793af7169b26d5",
+    ),
 )

--- a/test/io/io.jl
+++ b/test/io/io.jl
@@ -16,4 +16,11 @@
           Set("r_" .* lowercase.(reactions(matlabmodel)))
     @test Set(lowercase.(reactions(sbmlmodel))) ==
           Set("r_" .* lowercase.(reactions(jsonmodel)))
+
+    # specifically test parsing of gene-reaction associations in Recon
+    reconmodel = load_model(StandardModel, model_paths["Recon3D.json"])
+    @test n_reactions(reconmodel) == 10600
+    recon_grrs = [r.grr for (i, r) in reconmodel.reactions if !isnothing(r.grr)]
+    @test length(recon_grrs) == 5938
+    @test sum(length.(recon_grrs)) == 13903
 end


### PR DESCRIPTION
...which seems logical as they are interpreted as normal identifiers in matlab.

This should eventually fix #563 (not sure if the current small fix with underscore is enough, needs confirm).