### PR TITLE
Add deprecation warning

### DIFF
--- a/src/analysis/modifications/moment.jl
+++ b/src/analysis/modifications/moment.jl
@@ -36,6 +36,7 @@ flux_balance_analysis(
 """
 add_moment_constraints(kcats::Dict{String,Float64}, protein_mass_fraction::Float64) =
     (model, opt_model) -> begin
+        @warn("DEPRECATION WARNING: this function will be removed in future versions of COBREXA.jl in favor of a GECKO based formulation.")
 
         lbs, ubs = get_optmodel_bounds(opt_model) # to assign directions
         # get grrs and ignore empty blocks: TODO: fix importing to avoid this ugly conditional see #462

--- a/src/analysis/modifications/moment.jl
+++ b/src/analysis/modifications/moment.jl
@@ -36,7 +36,9 @@ flux_balance_analysis(
 """
 add_moment_constraints(kcats::Dict{String,Float64}, protein_mass_fraction::Float64) =
     (model, opt_model) -> begin
-        @warn("DEPRECATION WARNING: this function will be removed in future versions of COBREXA.jl in favor of a GECKO based formulation.")
+        @warn(
+            "DEPRECATION WARNING: this function will be removed in future versions of COBREXA.jl in favor of a GECKO based formulation."
+        )
 
         lbs, ubs = get_optmodel_bounds(opt_model) # to assign directions
         # get grrs and ignore empty blocks: TODO: fix importing to avoid this ugly conditional see #462


### PR DESCRIPTION
Adds a deprecation warning for the MOMENT modification. This will be replaced by a GECKO formulation of the enzyme capacity constrained problem. The current MOMENT implementation is simplistic. 