### PR TITLE
make stoichiometries easily extensible to encompass more complicated analyses

### DIFF
--- a/docs/src/advanced.md
+++ b/docs/src/advanced.md
@@ -5,4 +5,3 @@
 Pages = joinpath.("advanced", filter(x -> endswith(x, ".md"), readdir("advanced")))
 Depth = 2
 ```
-

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -5,4 +5,3 @@
 Pages = joinpath.("tutorials", filter(x -> endswith(x, ".md"), readdir("tutorials")))
 Depth = 2
 ```
-

--- a/src/analysis/flux_balance_analysis.jl
+++ b/src/analysis/flux_balance_analysis.jl
@@ -1,5 +1,5 @@
 """
-    flux_balance_analysis_vec(args...)::Maybe{Vector{Float64}}
+    flux_balance_analysis_vec(model::MetabolicModel, args...)::Maybe{Vector{Float64}}
 
 A variant of FBA that returns a vector of fluxes in the same order as reactions
 of the model, if the solution is found.
@@ -9,8 +9,12 @@ Arguments are passed to [`flux_balance_analysis`](@ref).
 This function is kept for backwards compatibility, use [`flux_vector`](@ref)
 instead.
 """
-flux_balance_analysis_vec(args...; kwargs...)::Maybe{Vector{Float64}} =
-    flux_vector(flux_balance_analysis(args...; kwargs...))
+flux_balance_analysis_vec(
+    model::MetabolicModel,
+    args...;
+    kwargs...,
+)::Maybe{Vector{Float64}} =
+    flux_vector(model, flux_balance_analysis(model, args...; kwargs...))
 
 """
     flux_balance_analysis_dict(model::MetabolicModel, args...)::Maybe{Dict{String, Float64}}

--- a/src/analysis/flux_variability_analysis.jl
+++ b/src/analysis/flux_variability_analysis.jl
@@ -1,7 +1,7 @@
 """
     flux_variability_analysis(
         model::MetabolicModel,
-        reactions::Vector{Int},
+        fluxes::Vector{Int},
         optimizer;
         modifications = [],
         workers = [myid()],
@@ -11,9 +11,9 @@
     )::Matrix{Float64}
 
 Flux variability analysis solves a pair of optimization problems in `model` for
-each flux listed in `reactions`:
+each flux `f` described in `fluxes`:
 ```
- min,max xᵢ
+min,max fᵀxᵢ
 s.t. S x = b
     xₗ ≤ x ≤ xᵤ
      cᵀx ≥ bounds(Z₀)[1]
@@ -38,13 +38,13 @@ multithreaded variability computation can be used to improve resource
 allocation efficiency in many common use-cases.
 
 `ret` is a function used to extract results from optimized JuMP models of the
-individual reactions. By default, it calls and returns the value of
+individual fluxes. By default, it calls and returns the value of
 `JuMP.objective_value`. More information can be extracted e.g. by setting it to
 a function that returns a more elaborate data structure; such as `m ->
 (JuMP.objective_value(m), JuMP.value.(m[:x]))`.
 
 Returns a matrix of extracted `ret` values for minima and maxima, of total size
-(`length(reactions)`,2). The optimizer result status is checked with
+(`size(fluxes,2)`,2). The optimizer result status is checked with
 [`is_solved`](@ref); `nothing` is returned if the optimization failed for any
 reason.
 
@@ -56,7 +56,7 @@ flux_variability_analysis(model, [1, 2, 3, 42], GLPK.optimizer)
 """
 function flux_variability_analysis(
     model::MetabolicModel,
-    reactions::Vector{Int},
+    fluxes::SparseMat,
     optimizer;
     modifications = [],
     workers = [myid()],
@@ -64,9 +64,13 @@ function flux_variability_analysis(
     bounds = z -> (z, Inf),
     ret = objective_value,
 )
-    #TODO this breaks if the flux doesn't correspond to the solution
-    if any(reactions .< 1) || any(reactions .> n_reactions(model))
-        throw(DomainError(reactions, "Index exceeds number of reactions."))
+    if size(fluxes, 1) != n_reactions(model)
+        throw(
+            DomainError(
+                size(fluxes, 1),
+                "Flux matrix size is not compatible with model reaction count.",
+            ),
+        )
     end
 
     Z = bounds(
@@ -75,6 +79,8 @@ function flux_variability_analysis(
             flux_balance_analysis(model, optimizer; modifications = modifications),
         ) : optimal_objective_value,
     )
+
+    flux_vector = [fluxes[:, i] for i = 1:size(fluxes, 2)]
 
     return screen_optmodel_modifications(
         model,
@@ -94,9 +100,33 @@ function flux_variability_analysis(
                 end,
             ],
         ),
-        args = Tuple.([-reactions reactions]),
-        analysis = (_, opt_model, ridx) -> _max_variability_flux(opt_model, ridx, ret),
+        args = tuple.([flux_vector flux_vector], [MIN_SENSE MAX_SENSE]),
+        analysis = (_, opt_model, flux, sense) ->
+            _max_variability_flux(opt_model, flux, sense, ret),
         workers = workers,
+    )
+end
+
+"""
+    flux_variability_analysis(model::MetabolicModel, flux_indexes::Vector{Int}, optimizer; kwargs...)
+
+An overload of [`flux_variability_analysis`](@ref) that explores the fluxes specified by integer indexes
+"""
+function flux_variability_analysis(
+    model::MetabolicModel,
+    flux_indexes::Vector{Int},
+    optimizer;
+    kwargs...,
+)
+    if any((flux_indexes .< 1) .| (flux_indexes .> n_fluxes(model)))
+        throw(DomainError(flux_indexes, "Flux index out of range"))
+    end
+
+    flux_variability_analysis(
+        model,
+        reaction_flux(model)[:, flux_indexes],
+        optimizer;
+        kwargs...,
     )
 end
 
@@ -108,12 +138,10 @@ end
     )
 
 A simpler version of [`flux_variability_analysis`](@ref) that maximizes and
-minimizes all reactions in the model. Arguments are forwarded.
+minimizes all declared fluxes in the model. Arguments are forwarded.
 """
-function flux_variability_analysis(model::MetabolicModel, optimizer; kwargs...)
-    n = n_reactions(model)
-    return flux_variability_analysis(model, collect(1:n), optimizer; kwargs...)
-end
+flux_variability_analysis(model::MetabolicModel, optimizer; kwargs...) =
+    flux_variability_analysis(model, reaction_flux(model), optimizer; kwargs...)
 
 """
     flux_variability_analysis_dict(
@@ -123,8 +151,8 @@ end
     )
 
 A variant of [`flux_variability_analysis`](@ref) that returns the individual
-maximized and minimized fluxes of all reactions as two dictionaries (of
-dictionaries). All keyword arguments except `ret` are passed through.
+maximized and minimized fluxes as two dictionaries (of dictionaries). All
+keyword arguments except `ret` are passed through.
 
 # Example
 ```
@@ -141,29 +169,71 @@ mins, maxs = flux_variability_analysis_dict(
 ```
 """
 function flux_variability_analysis_dict(model::MetabolicModel, optimizer; kwargs...)
-    fluxes = flux_variability_analysis(
+    vs = flux_variability_analysis(
         model,
         optimizer;
         kwargs...,
         ret = sol -> flux_vector(model, sol),
     )
-    rxns = reactions(model)
-    dicts = zip.(Ref(rxns), fluxes)
+    flxs = fluxes(model)
+    dicts = zip.(Ref(flxs), vs)
 
-    return (Dict(rxns .=> Dict.(dicts[:, 1])), Dict(rxns .=> Dict.(dicts[:, 2])))
+    return (Dict(flxs .=> Dict.(dicts[:, 1])), Dict(flxs .=> Dict.(dicts[:, 2])))
 end
 
 """
-    _max_variability_flux(opt_model, rid, ret)
+    _max_variability_flux(opt_model, flux, sense, ret)
 
 Internal helper for maximizing reactions in optimization model.
 """
-function _max_variability_flux(opt_model, rid, ret)
-    sense = rid > 0 ? MAX_SENSE : MIN_SENSE
-    var = all_variables(opt_model)[abs(rid)]
-
-    @objective(opt_model, sense, var)
+function _max_variability_flux(opt_model, flux, sense, ret)
+    @objective(opt_model, sense, sum(flux .* opt_model[:x]))
     optimize!(opt_model)
 
     is_solved(opt_model) ? ret(opt_model) : nothing
 end
+
+"""
+    reaction_variability_analysis(model::MetabolicModel, reaction_indexes::Vector{Int}, optimizer; kwargs...)
+
+A variant for [`flux_variability_analysis`](@ref) that examines actual
+reactions (selected by their indexes in `reactions` argument) instead of whole
+fluxes. This may be useful for models where the sets of reactions and fluxes
+differ.
+"""
+function reaction_variability_analysis(
+    model::MetabolicModel,
+    reaction_indexes::Vector{Int},
+    optimizer;
+    kwargs...,
+)
+    if any((reaction_indexes .< 1) .| (reaction_indexes .> n_reactions(model)))
+        throw(DomainError(reaction_indexes, "Flux index out of range"))
+    end
+
+    flux_variability_analysis(
+        model,
+        sparse(
+            reaction_indexes,
+            1:length(reaction_indexes),
+            1.0,
+            n_reactions(model),
+            length(reaction_indexes),
+        ),
+        optimizer;
+        kwargs...,
+    )
+end
+
+"""
+    reaction_variability_analysis( model::MetabolicModel, optimizer; kwargs...)
+
+Shortcut for [`reaction_variability_analysis`](@ref) that examines all reactions.
+"""
+reaction_variability_analysis(model::MetabolicModel, optimizer; kwargs...) =
+    reaction_variability_analysis(
+        model,
+        collect(1:n_reactions(model)),
+        optimizer;
+        kwargs...,
+    )

--- a/src/analysis/flux_variability_analysis.jl
+++ b/src/analysis/flux_variability_analysis.jl
@@ -64,6 +64,7 @@ function flux_variability_analysis(
     bounds = z -> (z, Inf),
     ret = objective_value,
 )
+    #TODO this breaks if the flux doesn't correspond to the solution
     if any(reactions .< 1) || any(reactions .> n_reactions(model))
         throw(DomainError(reactions, "Index exceeds number of reactions."))
     end
@@ -140,7 +141,12 @@ mins, maxs = flux_variability_analysis_dict(
 ```
 """
 function flux_variability_analysis_dict(model::MetabolicModel, optimizer; kwargs...)
-    fluxes = flux_variability_analysis(model, optimizer; kwargs..., ret = flux_vector)
+    fluxes = flux_variability_analysis(
+        model,
+        optimizer;
+        kwargs...,
+        ret = sol -> flux_vector(model, sol),
+    )
     rxns = reactions(model)
     dicts = zip.(Ref(rxns), fluxes)
 

--- a/src/analysis/minimize_metabolic_adjustment.jl
+++ b/src/analysis/minimize_metabolic_adjustment.jl
@@ -82,7 +82,7 @@ minimize_metabolic_adjustment(flux_ref_dict::Dict{String,Float64}) =
         )
 
 """
-    minimize_metabolic_adjustment_analysis_vec(args...; kwargs...)
+    minimize_metabolic_adjustment_analysis_vec(model::MetabolicModel, args...; kwargs...)
 
 Perform minimization of metabolic adjustment (MOMA) and return a vector of fluxes in the
 same order as the reactions in `model`. Arguments are forwarded to
@@ -91,8 +91,8 @@ same order as the reactions in `model`. Arguments are forwarded to
 This function is kept for backwards compatibility, use [`flux_vector`](@ref)
 instead.
 """
-minimize_metabolic_adjustment_analysis_vec(args...; kwargs...) =
-    flux_vector(minimize_metabolic_adjustment_analysis(args...; kwargs...))
+minimize_metabolic_adjustment_analysis_vec(model::MetabolicModel, args...; kwargs...) =
+    flux_vector(model, minimize_metabolic_adjustment_analysis(model, args...; kwargs...))
 
 """
     minimize_metabolic_adjustment_analysis_dict(model::MetabolicModel, args...; kwargs...)

--- a/src/analysis/parsimonious_flux_balance_analysis.jl
+++ b/src/analysis/parsimonious_flux_balance_analysis.jl
@@ -94,7 +94,7 @@ function parsimonious_flux_balance_analysis(
 end
 
 """
-    parsimonious_flux_balance_analysis_vec(args...; kwargs...)
+    parsimonious_flux_balance_analysis_vec(model::MetabolicModel, args...; kwargs...)
 
 Perform parsimonious flux balance analysis on `model` using `optimizer`.
 Returns a vector of fluxes in the same order as the reactions in `model`.
@@ -104,8 +104,8 @@ internally.
 This function is kept for backwards compatibility, use [`flux_vector`](@ref)
 instead.
 """
-parsimonious_flux_balance_analysis_vec(args...; kwargs...) =
-    flux_vector(parsimonious_flux_balance_analysis(args...; kwargs...))
+parsimonious_flux_balance_analysis_vec(model::MetabolicModel, args...; kwargs...) =
+    flux_vector(model, parsimonious_flux_balance_analysis(model, args...; kwargs...))
 
 """
     parsimonious_flux_balance_analysis_dict(model::MetabolicModel, args...; kwargs...)

--- a/src/analysis/sampling/affine_hit_and_run.jl
+++ b/src/analysis/sampling/affine_hit_and_run.jl
@@ -11,9 +11,9 @@
 
 Run a hit-and-run style sampling that starts from `warmup_points` and uses
 their affine combinations for generating the run directions to sample the space
-delimited by `lbs` and `ubs`.  The points that represent fluxes in
-`warmup_points` should be organized in columns, i.e. `warmup_points[:,1]` is
-the first warmup flux.
+delimited by `lbs` and `ubs`.  The reaction rate vectors in `warmup_points`
+should be organized in columns, i.e. `warmup_points[:,1]` is the first set of
+reaction rates.
 
 There are total `chains` of hit-and-run runs, each on a batch of
 `size(warmup_points, 2)` points. The runs are scheduled on `workers`, for good
@@ -25,9 +25,9 @@ points is collected for output. For example, `sample_iters=[1,4,5]` causes the
 process run for 5 iterations, returning the sample batch that was produced by
 1st, 4th and last (5th) iteration.
 
-Returns a matrix of sampled fluxes (in columns), with all collected samples
-horizontally concatenated. The total number of samples (columns) will be
-`size(warmup_points,2) * chains * length(sample_iters)`.
+Returns a matrix of sampled reaction rates (in columns), with all collected
+samples horizontally concatenated. The total number of samples (columns) will
+be `size(warmup_points,2) * chains * length(sample_iters)`.
 
 # Example
 ```
@@ -38,6 +38,9 @@ model = load_model(StandardModel, model_path)
 
 warmup, lbs, ubs = warmup_from_variability(model, Tulip.Optimizer, 100)
 samples = affine_hit_and_run(warmup, lbs, ubs, sample_iters = 1:3)
+
+# convert the result to flux (for models where the distinction matters):
+fluxes = reaction_flux(model)' * samples
 ```
 """
 function affine_hit_and_run(

--- a/src/banner.jl
+++ b/src/banner.jl
@@ -17,16 +17,16 @@ function _print_banner()
 
     println(
         "
-                   $(y)//   $(n) |
-        \\\\\\\\\\  // $(y)//    $(n) | $(c[:bold])COBREXA.jl $(c[:normal]) v$(COBREXA_VERSION)
-         \\\\ \\\\// $(y)//     $(n) |
-          \\\\ \\/ $(y)//      $(n) | $(c[:bold])CO$(c[:normal])nstraint-$(c[:bold])B$(c[:normal])ased $(c[:bold])R$(c[:normal])econstruction
-           \\\\  $(y)//       $(n) | and $(c[:bold])EX$(c[:normal])ascale $(c[:bold])A$(c[:normal])nalysis in Julia
-           //  $(y)\\\\       $(n) |
-          // $(y)/\\ \\\\      $(n) | See documentation and examples at:
-         // $(y)//\\\\ \\\\      $(n)| https://lcsb-biocore.github.io/COBREXA.jl
-        // $(y)//  \\\\\\\\\\     $(n)|
-       //                $(n)|
+                   $(y)//$(n)    |
+        \\\\\\\\\\  // $(y)//$(n)     | $(c[:bold])COBREXA.jl $(c[:normal]) v$(COBREXA_VERSION)
+         \\\\ \\\\// $(y)//$(n)      |
+          \\\\ \\/ $(y)//$(n)       | $(c[:bold])CO$(c[:normal])nstraint-$(c[:bold])B$(c[:normal])ased $(c[:bold])R$(c[:normal])econstruction
+           \\\\  $(y)//$(n)        | and $(c[:bold])EX$(c[:normal])ascale $(c[:bold])A$(c[:normal])nalysis in Julia
+           //  $(y)\\\\$(n)        |
+          // $(y)/\\ \\\\$(n)       | See documentation and examples at:
+         // $(y)//\\\\ \\\\$(n)      | https://lcsb-biocore.github.io/COBREXA.jl
+        // $(y)//  \\\\\\\\\\$(n)     |
+       //                |
         ",
     )
 end

--- a/src/base/solver.jl
+++ b/src/base/solver.jl
@@ -108,7 +108,7 @@ flux_vector(flux_balance_analysis(model, ...))
 ```
 """
 flux_vector(model::MetabolicModel, opt_model)::Maybe{Vector{Float64}} =
-    is_solved(opt_model) ? solution_flux(model, value.(opt_model[:x])) : nothing
+    is_solved(opt_model) ? reaction_flux(model)' * value.(opt_model[:x]) : nothing
 
 """
     flux_dict(model::MetabolicModel, opt_model)::Maybe{Dict{String, Float64}, Nothing}
@@ -122,4 +122,4 @@ flux_dict(model, flux_balance_analysis(model, ...))
 """
 flux_dict(model::MetabolicModel, opt_model)::Maybe{Dict{String,Float64}} =
     is_solved(opt_model) ?
-    Dict(reactions(model) .=> solution_flux(model, value.(opt_model[:x]))) : nothing
+    Dict(reactions(model) .=> reaction_flux(model)' * value.(opt_model[:x])) : nothing

--- a/src/base/solver.jl
+++ b/src/base/solver.jl
@@ -107,8 +107,8 @@ Returns a vector of fluxes of the model, if solved.
 flux_vector(flux_balance_analysis(model, ...))
 ```
 """
-flux_vector(opt_model)::Maybe{Vector{Float64}} =
-    is_solved(opt_model) ? value.(opt_model[:x]) : nothing
+flux_vector(model::MetabolicModel, opt_model)::Maybe{Vector{Float64}} =
+    is_solved(opt_model) ? solution_flux(model, value.(opt_model[:x])) : nothing
 
 """
     flux_dict(model::MetabolicModel, opt_model)::Maybe{Dict{String, Float64}, Nothing}
@@ -121,4 +121,5 @@ flux_dict(model, flux_balance_analysis(model, ...))
 ```
 """
 flux_dict(model::MetabolicModel, opt_model)::Maybe{Dict{String,Float64}} =
-    is_solved(opt_model) ? Dict(reactions(model) .=> value.(opt_model[:x])) : nothing
+    is_solved(opt_model) ?
+    Dict(reactions(model) .=> solution_flux(model, value.(opt_model[:x]))) : nothing

--- a/src/base/types/CoreModel.jl
+++ b/src/base/types/CoreModel.jl
@@ -93,7 +93,7 @@ Collect all genes contained in the [`CoreModel`](@ref). The call is expensive
 for large models, because the vector is not stored and instead gets rebuilt
 each time this function is called.
 """
-function genes(a::MetabolicModel)::Vector{String}
+function genes(a::CoreModel)::Vector{String}
     res = Set{String}()
     for grr in a.grrs
         isnothing(grr) && continue

--- a/src/base/types/CoreModel.jl
+++ b/src/base/types/CoreModel.jl
@@ -98,7 +98,9 @@ function genes(a::CoreModel)::Vector{String}
     for grr in a.grrs
         isnothing(grr) && continue
         for gs in grr
-            push!(res, gs)
+            for g in gs
+                push!(res, g)
+            end
         end
     end
     sort(collect(res))

--- a/src/base/types/CoreModelCoupled.jl
+++ b/src/base/types/CoreModelCoupled.jl
@@ -1,73 +1,100 @@
 
 """
-    struct CoreModelCoupled <: MetabolicModel
+    mutable struct CoreCoupling{M} <: ModelWrapper where {M<:MetabolicModel}
 
-The linear model with additional coupling constraints in the form
+A matrix-based wrap that adds reaction coupling matrix to the inner model. A
+flux `x` feasible in this model must satisfy:
 ```
     cₗ ≤ C x ≤ cᵤ
 ```
 """
-mutable struct CoreModelCoupled <: ModelWrapper
-    lm::CoreModel
+mutable struct CoreCoupling{M} <: ModelWrapper where {M<:MetabolicModel}
+    lm::M
     C::SparseMat
     cl::Vector{Float64}
     cu::Vector{Float64}
 
-    function CoreModelCoupled(lm::MetabolicModel, C::MatType, cl::VecType, cu::VecType)
+    function CoreCoupling(
+        lm::M,
+        C::MatType,
+        cl::VecType,
+        cu::VecType,
+    ) where {M<:MetabolicModel}
         length(cu) == length(cl) ||
             throw(DimensionMismatch("`cl` and `cu` need to have the same size"))
         size(C) == (length(cu), n_reactions(lm)) ||
             throw(DimensionMismatch("wrong dimensions of `C`"))
 
-        new(convert(CoreModel, lm), sparse(C), collect(cl), collect(cu))
+        new{M}(lm, sparse(C), collect(cl), collect(cu))
     end
 end
 
 """
-    unwrap_model(a::CoreModelCoupled)
+    unwrap_model(a::CoreCoupling)
 
-Get the internal [`CoreModel`](@ref) out of [`CoreModelCoupled`](@ref).
+Get the internal [`CoreModel`](@ref) out of [`CoreCoupling`](@ref).
 """
-unwrap_model(a::CoreModelCoupled) = a.lm
-
-"""
-    coupling(a::CoreModelCoupled)::SparseMat
-
-Coupling constraint matrix for a `CoreModelCoupled`.
-"""
-coupling(a::CoreModelCoupled)::SparseMat = a.C
+unwrap_model(a::CoreCoupling) = a.lm
 
 """
-    n_coupling_constraints(a::CoreModelCoupled)::Int
+    coupling(a::CoreCoupling)::SparseMat
 
-The number of coupling constraints in a `CoreModelCoupled`.
+Coupling constraint matrix for a `CoreCoupling`.
 """
-n_coupling_constraints(a::CoreModelCoupled)::Int = size(a.C, 1)
+coupling(a::CoreCoupling)::SparseMat = vcat(coupling(a.lm), a.C)
 
 """
-    coupling_bounds(a::CoreModelCoupled)::Tuple{Vector{Float64},Vector{Float64}}
+    n_coupling_constraints(a::CoreCoupling)::Int
 
-Coupling bounds for a `CoreModelCoupled`.
+The number of coupling constraints in a `CoreCoupling`.
 """
-coupling_bounds(a::CoreModelCoupled)::Tuple{Vector{Float64},Vector{Float64}} = (a.cl, a.cu)
+n_coupling_constraints(a::CoreCoupling)::Int = n_coupling_constraints(a.lm) + size(a.C, 1)
+
+"""
+    coupling_bounds(a::CoreCoupling)::Tuple{Vector{Float64},Vector{Float64}}
+
+Coupling bounds for a `CoreCoupling`.
+"""
+coupling_bounds(a::CoreCoupling)::Tuple{Vector{Float64},Vector{Float64}} =
+    vcat.(coupling_bounds(a.lm), (a.cl, a.cu))
+
+"""
+    Base.convert(::Type{CoreCoupling{M}}, mm::MetabolicModel; clone_coupling = true) where {M}
+
+Make a `CoreCoupling` out of any compatible model type.
+"""
+function Base.convert(
+    ::Type{CoreCoupling{M}},
+    mm::MetabolicModel;
+    clone_coupling = true,
+) where {M}
+    if mm isa CoreCoupling{M}
+        mm
+    elseif mm isa CoreCoupling
+        CoreCoupling(convert(M, mm.lm), mm.C, mm.cl, mm.cu)
+    elseif clone_coupling
+        (cl, cu) = coupling_bounds(mm)
+        CoreCoupling(convert(M, mm), coupling(mm), cl, cu)
+    else
+        CoreCoupling(convert(M, mm), spzeros(0, n_reactions(mm)), spzeros(0), spzeros(0))
+    end
+end
+
+"""
+    const CoreModelCoupled = CoreCoupling{CoreModel}
+
+A matrix-based linear model with additional coupling constraints in the form:
+```
+    cₗ ≤ C x ≤ cᵤ
+```
+
+Internally, the model is implemented using [`CoreCoupling`](@ref) that contains a single [`CoreModel`](@ref).
+"""
+const CoreModelCoupled = CoreCoupling{CoreModel}
+
+CoreModelCoupled(lm::CoreModel, C::MatType, cl::VecType, cu::VecType) =
+    CoreCoupling(lm, sparse(C), collect(cl), collect(cu))
 
 # these are special for CoreModel-ish models
 @_inherit_model_methods CoreModelCoupled () lm () reaction_gene_association_vec
 @_inherit_model_methods CoreModelCoupled (ridx::Int,) lm (ridx,) reaction_stoichiometry
-
-"""
-    Base.convert(::Type{CoreModelCoupled}, mm::MetabolicModel)
-
-Make a `CoreModelCoupled` out of any compatible model type.
-"""
-function Base.convert(::Type{CoreModelCoupled}, mm::MetabolicModel)
-    # TODO this might need a bit of rethinking and might be deprecated soon.
-    # Eventually it seems to me that the coupling should be added as a
-    # completely generic wrapper.
-    if typeof(mm) == CoreModelCoupled
-        return mm
-    end
-
-    (cl, cu) = coupling_bounds(mm)
-    CoreModelCoupled(convert(CoreModel, mm), coupling(mm), cl, cu)
-end

--- a/src/base/types/MetabolicModel.jl
+++ b/src/base/types/MetabolicModel.jl
@@ -87,14 +87,40 @@ function objective(a::MetabolicModel)::SparseVec
     _missing_impl_error(objective, (a,))
 end
 
-"""
-    solution_flux(a::MetabolicModel, solution::Vector{Float64})::Vector{Float64}
 
-Retrieve a vector of reaction fluxes (corresponding to `reactions(a)`) from a
-feasible solution of the optimization problem.
 """
-function solution_flux(a::MetabolicModel, solution::Vector{Float64})::Vector{Float64}
-    solution
+    fluxes(a::MetabolicModel)::Vector{String}
+
+In some models, the [`reactions`](@ref) that correspond to the columns of
+[`stoichiometry`](@ref) matrix do not fully represent the semantic contents of
+the model; for example, fluxes may be split into forward and reverse reactions,
+reactions catalyzed by distinct enzymes, etc. Together with
+[`reaction_flux`](@ref) (and [`n_fluxes`](@ref)) this specifies how the
+flux is decomposed into individual reactions.
+
+By default (and in most models), fluxes and reactions perfectly correspond.
+"""
+function fluxes(a::MetabolicModel)::Vector{String}
+    reactions(a)
+end
+
+function n_fluxes(a::MetabolicModel)::Int
+    n_reactions(a)
+end
+
+"""
+    reaction_flux(a::MetabolicModel)::SparseMat
+
+Retrieve a sparse matrix that describes the correspondence of a solution of the
+linear system to the fluxes (see [`fluxes`](@ref) for rationale). Returns a
+sparse matrix of size `(n_reactions(a), n_fluxes(a))`. For most models, this is
+an identity matrix.
+"""
+function reaction_flux(a::MetabolicModel)::SparseMat
+    nr = n_reactions(a)
+    nf = n_fluxes(a)
+    nr == nf || _missing_impl_error(reaction_flux, (a,))
+    spdiagm(fill(1, nr))
 end
 
 """

--- a/src/base/types/MetabolicModel.jl
+++ b/src/base/types/MetabolicModel.jl
@@ -46,7 +46,13 @@ end
 """
     stoichiometry(a::MetabolicModel)::SparseMat
 
-Get the sparse stoichiometry matrix of a model.
+Get the sparse stoichiometry matrix of a model. A feasible solution `x` of a
+model `m` is defined as satisfying the equations:
+
+- `stoichiometry(m) * x .== balance(m)`
+- `x .>= lbs`
+- `y .<= ubs`
+- `(lbs, ubs) == bounds(m)
 """
 function stoichiometry(a::MetabolicModel)::SparseMat
     _missing_impl_error(stoichiometry, (a,))
@@ -55,7 +61,7 @@ end
 """
     bounds(a::MetabolicModel)::Tuple{Vector{Float64},Vector{Float64}}
 
-Get the lower and upper flux bounds of a model.
+Get the lower and upper solution bounds of a model.
 """
 function bounds(a::MetabolicModel)::Tuple{Vector{Float64},Vector{Float64}}
     _missing_impl_error(bounds, (a,))
@@ -64,7 +70,7 @@ end
 """
     balance(a::MetabolicModel)::SparseVec
 
-Get the sparse balance vector of a model (ie. the `b` from `S x = b`).
+Get the sparse balance vector of a model.
 """
 function balance(a::MetabolicModel)::SparseVec
     return spzeros(n_metabolites(a))
@@ -73,10 +79,22 @@ end
 """
     objective(a::MetabolicModel)::SparseVec
 
-Get the objective vector of a model.
+Get the objective vector of the model. Analysis functions, such as
+[`flux_balance_analysis`](@ref), are supposed to maximize `dot(objective, x)`
+where `x` is a feasible solution of the model.
 """
 function objective(a::MetabolicModel)::SparseVec
     _missing_impl_error(objective, (a,))
+end
+
+"""
+    solution_flux(a::MetabolicModel, solution::Vector{Float64})::Vector{Float64}
+
+Retrieve a vector of reaction fluxes (corresponding to `reactions(a)`) from a
+feasible solution of the optimization problem.
+"""
+function solution_flux(a::MetabolicModel, solution::Vector{Float64})::Vector{Float64}
+    solution
 end
 
 """
@@ -86,6 +104,7 @@ Get a matrix of coupling constraint definitions of a model. By default, there
 is no coupling in the models.
 """
 function coupling(a::MetabolicModel)::SparseMat
+    # TODO make this an extension of stoichiometry
     return spzeros(0, n_reactions(a))
 end
 

--- a/src/base/types/MetabolicModel.jl
+++ b/src/base/types/MetabolicModel.jl
@@ -7,6 +7,8 @@
 # automatically derived methods for [`ModelWrapper`](@ref).
 #
 
+_missing_impl_error(m, a) = throw(MethodError(m, a))
+
 """
     reactions(a::MetabolicModel)::Vector{String}
 
@@ -130,7 +132,6 @@ Get a matrix of coupling constraint definitions of a model. By default, there
 is no coupling in the models.
 """
 function coupling(a::MetabolicModel)::SparseMat
-    # TODO make this an extension of stoichiometry
     return spzeros(0, n_reactions(a))
 end
 

--- a/src/base/types/ModelWrapper.jl
+++ b/src/base/types/ModelWrapper.jl
@@ -20,4 +20,4 @@ end
 
 @_inherit_model_methods_fn ModelWrapper (mid::String,) unwrap_model (mid,) metabolite_formula metabolite_charge metabolite_compartment metabolite_annotations metabolite_notes
 
-@_inherit_model_methods_fn ModelWrapper (gid::String,) unwrap_model (mid,) gene_annotations gene_notes
+@_inherit_model_methods_fn ModelWrapper (gid::String,) unwrap_model (gid,) gene_annotations gene_notes

--- a/src/base/types/ModelWrapper.jl
+++ b/src/base/types/ModelWrapper.jl
@@ -16,6 +16,8 @@ end
 
 @_inherit_model_methods_fn ModelWrapper () unwrap_model () reactions metabolites stoichiometry bounds balance objective coupling n_coupling_constraints coupling_bounds genes n_genes precache!
 
+@_inherit_model_methods_fn ModelWrapper (solution::Vector{Float64},) unwrap_model (solution,) solution_flux
+
 @_inherit_model_methods_fn ModelWrapper (rid::String,) unwrap_model (rid,) reaction_gene_association reaction_subsystem reaction_stoichiometry reaction_annotations reaction_notes
 
 @_inherit_model_methods_fn ModelWrapper (mid::String,) unwrap_model (mid,) metabolite_formula metabolite_charge metabolite_compartment metabolite_annotations metabolite_notes

--- a/src/base/types/ModelWrapper.jl
+++ b/src/base/types/ModelWrapper.jl
@@ -16,7 +16,9 @@ end
 
 @_inherit_model_methods_fn ModelWrapper () unwrap_model () reactions metabolites stoichiometry bounds balance objective coupling n_coupling_constraints coupling_bounds genes n_genes precache!
 
-@_inherit_model_methods_fn ModelWrapper (solution::Vector{Float64},) unwrap_model (solution,) solution_flux
+@_inherit_model_methods_fn ModelWrapper (solution::Vector{Float64},) unwrap_model (
+    solution,
+) solution_flux
 
 @_inherit_model_methods_fn ModelWrapper (rid::String,) unwrap_model (rid,) reaction_gene_association reaction_subsystem reaction_stoichiometry reaction_annotations reaction_notes
 

--- a/src/base/types/ModelWrapper.jl
+++ b/src/base/types/ModelWrapper.jl
@@ -14,11 +14,7 @@ end
 # The list of inherited functions must be synced with the methods available for [`MetabolicModel`](@ref).
 #
 
-@_inherit_model_methods_fn ModelWrapper () unwrap_model () reactions metabolites stoichiometry bounds balance objective coupling n_coupling_constraints coupling_bounds genes n_genes precache!
-
-@_inherit_model_methods_fn ModelWrapper (solution::Vector{Float64},) unwrap_model (
-    solution,
-) solution_flux
+@_inherit_model_methods_fn ModelWrapper () unwrap_model () reactions metabolites stoichiometry bounds balance objective fluxes n_fluxes reaction_flux coupling n_coupling_constraints coupling_bounds genes n_genes precache!
 
 @_inherit_model_methods_fn ModelWrapper (rid::String,) unwrap_model (rid,) reaction_gene_association reaction_subsystem reaction_stoichiometry reaction_annotations reaction_notes
 

--- a/src/base/types/abstract/MetabolicModel.jl
+++ b/src/base/types/abstract/MetabolicModel.jl
@@ -64,5 +64,3 @@ Free-form notes about something (e.g. a [`Gene`](@ref)), categorized by
 "topic".
 """
 const Notes = Dict{String,Vector{String}}
-
-_missing_impl_error(m, a) = throw(MethodError(m, a))

--- a/src/reconstruction/CoreModelCoupled.jl
+++ b/src/reconstruction/CoreModelCoupled.jl
@@ -165,13 +165,14 @@ function add_reactions(
 end
 
 """
-Add constraints of the following form to a CoreModelCoupled and return a modified one.
+    add_coupling_constraints(m::CoreCoupling, args...)
 
-Add constraints to a [`CoreModelCoupled`](@ref) and return a modified one.
+Add constraints of the following form to CoreCoupling and return the modified
+model.
 
 The arguments are same as for in-place [`add_coupling_constraints!`](@ref).
 """
-function add_coupling_constraints(m::CoreModelCoupled, args...)
+function add_coupling_constraints(m::CoreCoupling, args...)
     new_lp = deepcopy(m)
     add_coupling_constraints!(new_lp, args...)
     return new_lp
@@ -183,12 +184,11 @@ end
 Add coupling constraints to a plain [`CoreModel`](@ref) (returns a
 [`CoreModelCoupled`](@ref)).
 """
-add_coupling_constraints(m::CoreModel, args...) =
-    add_coupling_constraints(convert(CoreModelCoupled, m), args...)
+add_coupling_constraints(m::CoreModel, args...) = CoreModelCoupled(m, args...)
 
 """
     add_coupling_constraints!(
-        m::CoreModelCoupled,
+        m::CoreCoupling,
         c::VecType,
         cl::AbstractFloat,
         cu::AbstractFloat,
@@ -197,7 +197,7 @@ add_coupling_constraints(m::CoreModel, args...) =
 Overload for adding a single coupling constraint.
 """
 function add_coupling_constraints!(
-    m::CoreModelCoupled,
+    m::CoreCoupling,
     c::VecType,
     cl::AbstractFloat,
     cu::AbstractFloat,
@@ -207,7 +207,7 @@ end
 
 """
     add_coupling_constraints!(
-        m::CoreModelCoupled,
+        m::CoreCoupling,
         C::MatType,
         cl::V,
         cu::V,
@@ -219,7 +219,7 @@ In-place add a single coupling constraint in form
 ```
 """
 function add_coupling_constraints!(
-    m::CoreModelCoupled,
+    m::CoreCoupling,
     C::MatType,
     cl::V,
     cu::V,
@@ -237,35 +237,34 @@ function add_coupling_constraints!(
 end
 
 """
-    remove_coupling_constraints(m::CoreModelCoupled, args...)
+    remove_coupling_constraints(m::CoreCoupling, args...)
 
 Remove coupling constraints from the linear model, and return the modified
 model. Arguments are the same as for in-place version
 [`remove_coupling_constraints!`](@ref).
 """
-function remove_coupling_constraints(m::CoreModelCoupled, args...)
+function remove_coupling_constraints(m::CoreCoupling, args...)
     new_model = deepcopy(m)
     remove_coupling_constraints!(new_model, args...)
     return new_model
 end
 
 """
-    remove_coupling_constraints!(m::CoreModelCoupled, constraint::Int)
+    remove_coupling_constraints!(m::CoreCoupling, constraint::Int)
 
-Removes a single coupling constraints from a [`CoreModelCoupled`](@ref)
-in-place.
+Removes a single coupling constraints from a [`CoreCoupling`](@ref) in-place.
 """
-remove_coupling_constraints!(m::CoreModelCoupled, constraint::Int) =
+remove_coupling_constraints!(m::CoreCoupling, constraint::Int) =
     remove_coupling_constraints!(m, [constraint])
 
 
 """
-    remove_coupling_constraints!(m::CoreModelCoupled, constraints::Vector{Int})
+    remove_coupling_constraints!(m::CoreCoupling, constraints::Vector{Int})
 
-Removes a set of coupling constraints from a [`CoreModelCoupled`](@ref)
+Removes a set of coupling constraints from a [`CoreCoupling`](@ref)
 in-place.
 """
-function remove_coupling_constraints!(m::CoreModelCoupled, constraints::Vector{Int})
+function remove_coupling_constraints!(m::CoreCoupling, constraints::Vector{Int})
     to_be_kept = filter(!in(constraints), 1:n_coupling_constraints(m))
     m.C = m.C[to_be_kept, :]
     m.cl = m.cl[to_be_kept]
@@ -275,7 +274,7 @@ end
 
 """
     change_coupling_bounds!(
-        model::CoreModelCoupled,
+        model::CoreCoupling,
         constraints::Vector{Int};
         cl::V = Float64[],
         cu::V = Float64[],
@@ -285,7 +284,7 @@ Change the lower and/or upper bounds (`cl` and `cu`) for the given list of
 coupling constraints.
 """
 function change_coupling_bounds!(
-    model::CoreModelCoupled,
+    model::CoreCoupling,
     constraints::Vector{Int};
     cl::V = Float64[],
     cu::V = Float64[],
@@ -309,131 +308,131 @@ function change_coupling_bounds!(
     nothing
 end
 
-@_change_bounds_fn CoreModelCoupled Int inplace begin
+# TODO see if some of these can be derived from ModelWrapper
+@_change_bounds_fn CoreCoupling Int inplace begin
     change_bound!(model.lm, rxn_idx, lower = lower, upper = upper)
 end
 
-@_change_bounds_fn CoreModelCoupled Int inplace plural begin
+@_change_bounds_fn CoreCoupling Int inplace plural begin
     change_bounds!(model.lm, rxn_idxs, lower = lower, upper = upper)
 end
 
-@_change_bounds_fn CoreModelCoupled String inplace begin
+@_change_bounds_fn CoreCoupling String inplace begin
     change_bound!(model.lm, rxn_id, lower = lower, upper = upper)
 end
 
-@_change_bounds_fn CoreModelCoupled String inplace plural begin
+@_change_bounds_fn CoreCoupling String inplace plural begin
     change_bounds!(model.lm, rxn_ids, lower = lower, upper = upper)
 end
 
-@_change_bounds_fn CoreModelCoupled Int begin
+@_change_bounds_fn CoreCoupling Int begin
     n = copy(model)
     n.lm = change_bound(model.lm, rxn_idx, lower = lower, upper = upper)
     n
 end
 
-@_change_bounds_fn CoreModelCoupled Int plural begin
+@_change_bounds_fn CoreCoupling Int plural begin
     n = copy(model)
     n.lm = change_bounds(model.lm, rxn_idxs, lower = lower, upper = upper)
     n
 end
 
-@_change_bounds_fn CoreModelCoupled String begin
+@_change_bounds_fn CoreCoupling String begin
     n = copy(model)
     n.lm = change_bound(model.lm, rxn_id, lower = lower, upper = upper)
     n
 end
 
-@_change_bounds_fn CoreModelCoupled String plural begin
+@_change_bounds_fn CoreCoupling String plural begin
     n = copy(model)
     n.lm = change_bounds(model.lm, rxn_ids, lower = lower, upper = upper)
     n
 end
 
-@_remove_fn reaction CoreModelCoupled Int inplace begin
+@_remove_fn reaction CoreCoupling Int inplace begin
     remove_reactions!(model, [reaction_idx])
 end
 
-@_remove_fn reaction CoreModelCoupled Int inplace plural begin
+@_remove_fn reaction CoreCoupling Int inplace plural begin
     orig_rxns = reactions(model.lm)
     remove_reactions!(model.lm, reaction_idxs)
     model.C = model.C[:, in.(orig_rxns, Ref(Set(reactions(model.lm))))]
     nothing
 end
 
-@_remove_fn reaction CoreModelCoupled Int begin
+@_remove_fn reaction CoreCoupling Int begin
     remove_reactions(model, [reaction_idx])
 end
 
-@_remove_fn reaction CoreModelCoupled Int plural begin
+@_remove_fn reaction CoreCoupling Int plural begin
     n = copy(model)
     n.lm = remove_reactions(n.lm, reaction_idxs)
     n.C = n.C[:, in.(reactions(model.lm), Ref(Set(reactions(n.lm))))]
     return n
 end
 
-@_remove_fn reaction CoreModelCoupled String inplace begin
+@_remove_fn reaction CoreCoupling String inplace begin
     remove_reactions!(model, [reaction_id])
 end
 
-@_remove_fn reaction CoreModelCoupled String inplace plural begin
+@_remove_fn reaction CoreCoupling String inplace plural begin
     remove_reactions!(model, Int.(indexin(reaction_ids, reactions(model))))
 end
 
-@_remove_fn reaction CoreModelCoupled String begin
+@_remove_fn reaction CoreCoupling String begin
     remove_reactions(model, [reaction_id])
 end
 
-@_remove_fn reaction CoreModelCoupled String plural begin
+@_remove_fn reaction CoreCoupling String plural begin
     remove_reactions(model, Int.(indexin(reaction_ids, reactions(model))))
 end
 
-@_remove_fn metabolite CoreModelCoupled Int inplace begin
+@_remove_fn metabolite CoreCoupling Int inplace begin
     remove_metabolites!(model, [metabolite_idx])
 end
 
-@_remove_fn metabolite CoreModelCoupled Int plural inplace begin
+@_remove_fn metabolite CoreCoupling Int plural inplace begin
     orig_rxns = reactions(model.lm)
     model.lm = remove_metabolites(model.lm, metabolite_idxs)
     model.C = model.C[:, in.(orig_rxns, Ref(Set(reactions(model.lm))))]
     nothing
 end
 
-@_remove_fn metabolite CoreModelCoupled Int begin
+@_remove_fn metabolite CoreCoupling Int begin
     remove_metabolites(model, [metabolite_idx])
 end
 
-@_remove_fn metabolite CoreModelCoupled Int plural begin
-    n = deepcopy(model) #almost everything gets changed anyway
-    remove_metabolites!(n, metabolite_idxs)
+@_remove_fn metabolite CoreCoupling Int plural begin
+    n = copy(model)
+    n.lm = remove_metabolites(n.lm, metabolite_idxs)
     return n
 end
 
-@_remove_fn metabolite CoreModelCoupled String inplace begin
+@_remove_fn metabolite CoreCoupling String inplace begin
     remove_metabolites!(model, [metabolite_id])
 end
 
-@_remove_fn metabolite CoreModelCoupled String inplace plural begin
+@_remove_fn metabolite CoreCoupling String inplace plural begin
     remove_metabolites!(model, Int.(indexin(metabolite_ids, metabolites(model))))
 end
 
-@_remove_fn metabolite CoreModelCoupled String begin
+@_remove_fn metabolite CoreCoupling String begin
     remove_metabolites(model, [metabolite_id])
 end
 
-@_remove_fn metabolite CoreModelCoupled String plural begin
+@_remove_fn metabolite CoreCoupling String plural begin
     remove_metabolites(model, Int.(indexin(metabolite_ids, metabolites(model))))
 end
 
 """
     change_objective!(
-        model::CoreModelCoupled,
+        model::CoreCoupling,
         args...;
         kwargs...,
     )
 
-Forwards arguments to [`change_objective!`](@ref) of the internal
-[`CoreModel`](@ref).
+Forwards arguments to [`change_objective!`](@ref) of the internal model.
 """
-function change_objective!(model::CoreModelCoupled, args...; kwargs...)
+function change_objective!(model::CoreCoupling, args...; kwargs...)
     change_objective!(model.lm, args...; kwargs...)
 end

--- a/test/analysis/flux_variability_analysis.jl
+++ b/test/analysis/flux_variability_analysis.jl
@@ -9,6 +9,9 @@
         2.0 2.0
     ]
 
+    rates = reaction_variability_analysis(cp, optimizer)
+    @test fluxes == rates
+
     fluxes = flux_variability_analysis(cp, [2], optimizer)
 
     @test size(fluxes) == (1, 2)


### PR DESCRIPTION
This does several things:

- `CoreModelCoupled` logic is split into `CoreCoupling` and a tiny glue that creates `CoreModelCoupled = CoreCoupling{CoreModel}`. As a main difference, CoreCoupling can be attached to anything. We might later have some kind of `StandardCoupling` as a objectish counterpart similarly as with `StandardModel`
- the notion of `reaction` as a "column of stoichiometry" is slightly wrapped in another notion of `flux`. Fluxes are by default completely isomorphic to reactions, but models may specify a more complicated mapping (e.g. when mapping 
- Analysis functions are adjusted accordingly (still there's a TODO for FVA)

The whole change is a preparation for models that require split-reactions and various other non-semantic helper material in stoichiometry.

EDITS:
- PR #600 is still not taken!!!!!!!!!!!!!!!11111
- I can probably split this into the CoreModelCoupled work, fluxes work and "various minor fixes" PRs, in case one part is disputable.