### PR TITLE
Add some accessors for MATModel

### DIFF
--- a/src/base/constants.jl
+++ b/src/base/constants.jl
@@ -24,6 +24,12 @@ const _constants = (
         objective = ["c"],
         grrs = ["gene_reaction_rules", "grRules", "rules"],
         ids = ["id", "description"],
+        metformulas = ["metFormula", "metFormulas"],
+        metcharges = ["metCharge", "metCharges"],
+        metcompartments = ["metCompartment", "metCompartments"],
+        rxnnames = ["rxnNames",],
+        metnames = ["metNames",],
+
     ),
     gene_annotation_checks = (
         "ncbigene",

--- a/src/base/constants.jl
+++ b/src/base/constants.jl
@@ -27,9 +27,8 @@ const _constants = (
         metformulas = ["metFormula", "metFormulas"],
         metcharges = ["metCharge", "metCharges"],
         metcompartments = ["metCompartment", "metCompartments"],
-        rxnnames = ["rxnNames",],
-        metnames = ["metNames",],
-
+        rxnnames = ["rxnNames"],
+        metnames = ["metNames"],
     ),
     gene_annotation_checks = (
         "ncbigene",

--- a/src/base/types/MATModel.jl
+++ b/src/base/types/MATModel.jl
@@ -152,10 +152,13 @@ metabolite_formula(m::MATModel, mid::String) = _maybemap(
 
 Extract metabolite charge from `metCharge` or `metCharges`.
 """
-metabolite_charge(m::MATModel, mid::String) = _maybemap(
-    x -> x[findfirst(==(mid), metabolites(m))],
-    get(m.mat, "metCharge", get(m.mat, "metCharges", nothing)),
-)
+function metabolite_charge(m::MATModel, mid::String)
+    met_charge = _maybemap(
+        x -> x[findfirst(==(mid), metabolites(m))],
+        get(m.mat, "metCharge", get(m.mat, "metCharges", nothing)),
+    )
+    isnan(met_charge) ? 0 : met_charge
+end
 
 """
     metabolite_compartment(m::MATModel, mid::String)
@@ -244,3 +247,19 @@ function Base.convert(::Type{MATModel}, m::MetabolicModel)
         ),
     )
 end
+
+"""
+    reaction_name(m::MATModel, mid::String)
+
+Extract metabolite compartment from `rxnNames`.
+"""
+reaction_name(m::MATModel, rid::String) =
+    _maybemap(x -> x[findfirst(==(rid), reactions(m))], get(m.mat, "rxnNames", nothing))
+
+"""
+    metabolite_name(m::MATModel, mid::String)
+
+Extract metabolite compartment from `metNames`.
+"""
+metabolite_name(m::MATModel, mid::String) =
+    _maybemap(x -> x[findfirst(==(mid), metabolites(m))], get(m.mat, "metNames", nothing))

--- a/src/base/types/MATModel.jl
+++ b/src/base/types/MATModel.jl
@@ -144,7 +144,7 @@ Extract metabolite formula from key `metFormula` or `metFormulas`.
 """
 metabolite_formula(m::MATModel, mid::String) = _maybemap(
     x -> _parse_formula(x[findfirst(==(mid), metabolites(m))]),
-    get(m.mat, "metFormula", get(m.mat, "metFormulas", nothing)),
+    gets(m.mat, nothing, _constants.keynames.metformulas),
 )
 
 """
@@ -155,7 +155,7 @@ Extract metabolite charge from `metCharge` or `metCharges`.
 function metabolite_charge(m::MATModel, mid::String)
     met_charge = _maybemap(
         x -> x[findfirst(==(mid), metabolites(m))],
-        get(m.mat, "metCharge", get(m.mat, "metCharges", nothing)),
+        gets(m.mat, nothing, _constants.keynames.metcharges),
     )
     isnan(met_charge) ? 0 : met_charge
 end
@@ -167,9 +167,8 @@ Extract metabolite compartment from `metCompartment` or `metCompartments`.
 """
 metabolite_compartment(m::MATModel, mid::String) = _maybemap(
     x -> x[findfirst(==(mid), metabolites(m))],
-    get(m.mat, "metCompartment", get(m.mat, "metCompartments", nothing)),
+    gets(m.mat, nothing, _constants.keynames.metcompartments),
 )
-
 
 """
     reaction_stoichiometry(model::MATModel, rid::String)::Dict{String, Float64}
@@ -251,15 +250,15 @@ end
 """
     reaction_name(m::MATModel, mid::String)
 
-Extract metabolite compartment from `rxnNames`.
+Extract reaction name from `rxnNames`.
 """
 reaction_name(m::MATModel, rid::String) =
-    _maybemap(x -> x[findfirst(==(rid), reactions(m))], get(m.mat, "rxnNames", nothing))
+    _maybemap(x -> x[findfirst(==(rid), reactions(m))], gets(m.mat, nothing, _constants.keynames.rxnnames))
 
 """
     metabolite_name(m::MATModel, mid::String)
 
-Extract metabolite compartment from `metNames`.
+Extract metabolite name from `metNames`.
 """
 metabolite_name(m::MATModel, mid::String) =
-    _maybemap(x -> x[findfirst(==(mid), metabolites(m))], get(m.mat, "metNames", nothing))
+    _maybemap(x -> x[findfirst(==(mid), metabolites(m))], gets(m.mat, nothing, _constants.keynames.metnames))

--- a/src/base/types/MATModel.jl
+++ b/src/base/types/MATModel.jl
@@ -252,13 +252,17 @@ end
 
 Extract reaction name from `rxnNames`.
 """
-reaction_name(m::MATModel, rid::String) =
-    _maybemap(x -> x[findfirst(==(rid), reactions(m))], gets(m.mat, nothing, _constants.keynames.rxnnames))
+reaction_name(m::MATModel, rid::String) = _maybemap(
+    x -> x[findfirst(==(rid), reactions(m))],
+    gets(m.mat, nothing, _constants.keynames.rxnnames),
+)
 
 """
     metabolite_name(m::MATModel, mid::String)
 
 Extract metabolite name from `metNames`.
 """
-metabolite_name(m::MATModel, mid::String) =
-    _maybemap(x -> x[findfirst(==(mid), metabolites(m))], gets(m.mat, nothing, _constants.keynames.metnames))
+metabolite_name(m::MATModel, mid::String) = _maybemap(
+    x -> x[findfirst(==(mid), metabolites(m))],
+    gets(m.mat, nothing, _constants.keynames.metnames),
+)

--- a/src/base/utils/guesskey.jl
+++ b/src/base/utils/guesskey.jl
@@ -20,3 +20,17 @@ function _guesskey(avail, possibilities)
     end
     return x[1]
 end
+
+"""
+    gets(collection, fail, keys)
+
+Return `fail` if key in `keys` is not in `collection`, otherwise
+return `collection[key]`. Useful if may different keys need to be 
+tried due to non-standardized model formats.
+"""
+function gets(collection, fail, keys)
+    for key in keys
+        haskey(collection, key) && return collection[key]
+    end
+    return fail
+end


### PR DESCRIPTION
Add some small accessors to MATModel so that the consensus yeast model can at least be imported without error. The model uses too many non-standard fields to make the import process totally smooth...