### PR TITLE
Check format using github actions, implement the `/format` command

### DIFF
--- a/.github/workflows/pr-cmd-format.yml
+++ b/.github/workflows/pr-cmd-format.yml
@@ -1,0 +1,53 @@
+
+on:
+  issue_comment:
+    types: [created]
+
+name: PR auto-formatting command
+
+jobs:
+  format:
+    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.issue.user.id == github.event.comment.user.id) && startsWith(github.event.comment.body, '/format') }}
+    name: auto-format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the repository
+        uses: actions/checkout@v2
+      - name: Checkout the pull request code
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr checkout ${{ github.event.issue.number }}
+      - name: Install JuliaFormatter and format
+        run: |
+          julia -e 'import Pkg; Pkg.add("JuliaFormatter")'
+          julia -e 'using JuliaFormatter; format(".")'
+      - name: Remove trailing whitespace
+        run: |
+          find -name '*.jl' -or -name '*.md' -or -name '*.toml' -or -name '*.yml' | while read filename ; do
+            # remove any trailing spaces
+            sed --in-place -e 's/\s*$//' "$filename"
+            # add a final newline if missing
+            if [[ -s "$filename" && $(tail -c 1 "$filename" |wc -l) -eq 0 ]] ; then
+              echo >> "$filename"
+            fi
+            # squash superfluous final newlines
+            sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' "$filename"
+          done
+      - name: Commit and push the changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ `git status -s | wc -l` -ne 0 ] ; then
+            git config --local user.name "$GITHUB_ACTOR"
+            git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+            git commit -a -m "automatic formatting" -m "triggered by @$GITHUB_ACTOR on PR #${{ github.event.issue.number }}"
+            if git push
+            then gh pr comment ${{ github.event.issue.number }} --body \
+              ":heavy_check_mark: auto-formatting triggered by [this comment](${{ github.event.comment.html_url }}) succeeded, commited as `git rev-parse HEAD`"
+            else gh pr comment ${{ github.event.issue.number }} --body \
+              ":x: auto-formatting triggered by [this comment](${{ github.event.comment.html_url }}) failed, perhaps someone pushed to the PR in the meantime?"
+            fi
+          else
+            echo "No changes, all good!"
+          fi

--- a/.github/workflows/pr-formatcheck.yml
+++ b/.github/workflows/pr-formatcheck.yml
@@ -1,0 +1,41 @@
+
+on:
+  pull_request:
+
+name: Formatting check
+
+jobs:
+  formatcheck:
+    name: check-code-format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v2
+      - name: Install JuliaFormatter and format
+        run: |
+          julia -e 'import Pkg; Pkg.add("JuliaFormatter")'
+          julia -e 'using JuliaFormatter; format(".")'
+      - name: Remove trailing whitespace
+        run: |
+          find -name '*.jl' -or -name '*.md' -or -name '*.toml' -or -name '*.yml' | while read filename ; do
+            # remove any trailing spaces
+            sed --in-place -e 's/\s*$//' "$filename"
+            # add a final newline if missing
+            if [[ -s "$filename" && $(tail -c 1 "$filename" |wc -l) -eq 0 ]] ; then
+              echo >> "$filename"
+            fi
+            # squash superfluous final newlines
+            sed -i -e :a -e '/^\n*$/{$d;N;};/\n$/ba' "$filename"
+          done
+      - name: Report any problems
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ `git status -s | wc -l` -ne 0 ]
+          then gh pr comment ${{ github.event.number }} --body \
+          ":red_square: &nbsp;Commit ${{ github.event.pull_request.head.sha }} requires formatting!\
+          "$'\n\n'"Required formatting changes summary:\
+          "$'\n```\n'"`git diff --stat`"$'\n```'
+          else gh pr comment ${{ github.event.number }} --body \
+          ":green_circle: &nbsp;Commit ${{ github.event.pull_request.head.sha }} is formatted properly."
+          fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -190,44 +190,6 @@ mac:julia1.6:
   <<: *global_env_mac
 
 #
-# CODE FORMAT CHECKER
-#
-
-format:
-  stage: test
-  script:
-    - |
-      docker run -v "$PWD":/project $CI_REGISTRY/r3/docker/julia-custom julia -e 'using JuliaFormatter; format("/project", verbose=true);'
-    - |
-      if [ `docker run -i -v "$PWD":/git alpine/git status -s | wc -l` -ne 0 ] ; then
-        GITHUB_COMMENT=":red_square: &nbsp;Commit ${CI_COMMIT_SHORT_SHA} requires formatting!\
-      "$'\n\n'"Required formatting changes summary:\
-      "$'\n```\n'"`docker run -i -v \"$PWD\":/git alpine/git diff --stat`"$'\n```'
-      else
-        GITHUB_COMMENT=":green_circle: &nbsp;Commit ${CI_COMMIT_SHORT_SHA} is formatted properly."
-      fi
-    - |
-      export GITHUB_TOKEN="${GITHUB_ACCESS_TOKEN_FORMATTER}"
-      export GITHUB_OWNER="lcsb-biocore"
-      export GITHUB_REPO="cobrexa.jl"
-      export GITHUB_COMMENT_TYPE=pr
-      export GITHUB_PR_ISSUE_NUMBER="${CI_EXTERNAL_PULL_REQUEST_IID}"
-      export GITHUB_COMMENT_FORMAT=""
-      export GITHUB_COMMENT
-    - |
-      docker run -i --rm \
-            -e GITHUB_TOKEN \
-            -e GITHUB_OWNER \
-            -e GITHUB_REPO \
-            -e GITHUB_COMMENT_TYPE \
-            -e GITHUB_PR_ISSUE_NUMBER \
-            -e GITHUB_COMMENT_FORMAT \
-            -e GITHUB_COMMENT \
-            cloudposse/github-commenter
-  <<: *global_dind
-  <<: *global_trigger_pull_request
-
-#
 # ASSETS
 #
 # This builds the development history gif using gource, and some containers.

--- a/src/analysis/gecko.jl
+++ b/src/analysis/gecko.jl
@@ -147,24 +147,15 @@ function make_gecko_model(
         push!(coupling_row_mass_group, _gecko_capacity(grp, idxs, mms, gmgb_(grp)))
     end
 
-    # create model with dummy objective
-    gm = GeckoModel(
-        spzeros(length(columns) + length(coupling_row_gene_product)),
+    GeckoModel(
+        [
+            _gecko_reaction_column_reactions(columns, model)' * objective(model)
+            spzeros(length(coupling_row_gene_product))
+        ],
         columns,
         coupling_row_reaction,
         collect(zip(coupling_row_gene_product, gpb_.(gids[coupling_row_gene_product]))),
         coupling_row_mass_group,
         model,
     )
-
-    #=
-    Set objective. This is a separate field because gene products can also be objectives. 
-    This way they can be set as objectives by the user.
-    =#
-    gm.objective .= [
-        _gecko_reaction_column_reactions(gm)' * objective(gm.inner)
-        spzeros(length(coupling_row_gene_product))
-    ]
-
-    return gm
 end

--- a/src/base/types/wrappers/GeckoModel.jl
+++ b/src/base/types/wrappers/GeckoModel.jl
@@ -16,7 +16,7 @@ end
 """
     struct _gecko_capacity
 
-A helper struct that contains the gene product capacity terms organized by 
+A helper struct that contains the gene product capacity terms organized by
 the grouping type, e.g. metabolic or membrane groups etc.
 """
 struct _gecko_capacity
@@ -217,7 +217,7 @@ end
 """
     balance(model::GeckoModel)
 
-Return the balance of the reactions in the inner model, concatenated with a vector of 
+Return the balance of the reactions in the inner model, concatenated with a vector of
 zeros representing the enzyme balance of a [`GeckoModel`](@ref).
 """
 balance(model::GeckoModel) =
@@ -233,7 +233,7 @@ n_genes(model::GeckoModel) = length(model.coupling_row_gene_product)
 """
     genes(model::GeckoModel)
 
-Return the gene ids of genes that have enzymatic constraints associated with them.  
+Return the gene ids of genes that have enzymatic constraints associated with them.
 """
 genes(model::GeckoModel) =
     genes(model.inner)[[idx for (idx, _) in model.coupling_row_gene_product]]

--- a/src/base/utils/gecko.jl
+++ b/src/base/utils/gecko.jl
@@ -15,12 +15,20 @@ _gecko_reaction_name(original_name::String, direction::Int, isozyme_idx::Int) =
 Retrieve a utility mapping between reactions and split reactions; rows
 correspond to "original" reactions, columns correspond to "split" reactions.
 """
-_gecko_reaction_column_reactions(model::GeckoModel) = sparse(
-    [col.reaction_idx for col in model.columns],
-    1:length(model.columns),
-    [col.direction >= 0 ? 1 : -1 for col in model.columns],
-    n_reactions(model.inner),
-    length(model.columns),
+_gecko_reaction_column_reactions(model::GeckoModel) =
+    _gecko_reaction_column_reactions(model.columns, model.inner)
+
+"""
+    _gecko_reaction_column_reactions(columns, inner)
+
+Helper method that doesn't require the whole [`GeckoModel`](@ref).
+"""
+_gecko_reaction_column_reactions(columns, inner) = sparse(
+    [col.reaction_idx for col in columns],
+    1:length(columns),
+    [col.direction >= 0 ? 1 : -1 for col in columns],
+    n_reactions(inner),
+    length(columns),
 )
 
 """

--- a/test/analysis/gecko.jl
+++ b/test/analysis/gecko.jl
@@ -54,7 +54,7 @@ end
 
 @testset "GECKO small model" begin
     #=
-    Implement the small model found in the supplment of the 
+    Implement the small model found in the supplment of the
     original GECKO paper. This model is nice to troubleshoot with,
     because the stoich matrix is small.
     =#


### PR DESCRIPTION
This implements the functionality required for finally closing #322 . Additionally this implements simple whitespace error checkers for eof newlines and trailing spaces.

I decided against opening purely technical shortlived PRs by the bot -- the `/format` command literally just pushes a single commit that can be erased if people don't like it. Also, the opening of PRs causes substantial clicking overhead (and a lot of noise in my mailbox), and seems more fragile.

The code needs to reach the default branch before the `/format` command will work.

Demo follows below.

PS. the PR includes a tiny change in the internals of GeckoModel that I saw while fixing the space errors and didn't want to make yet another gecko PR about it.

## Confirmation that formatting is ok
![image](https://user-images.githubusercontent.com/271543/168472553-f8963ac1-830a-49fd-92b0-cef1735ed3a2.png)

## Message about formatting deficiencies
![image](https://user-images.githubusercontent.com/271543/168472604-5e3f4058-0c13-4fbc-ba61-4108d3554359.png)

## Formatting command, success message and the commit
![image](https://user-images.githubusercontent.com/271543/168472625-6f0c6b63-7058-4bf2-9c8d-d40c968f7eb7.png)
