### PR TITLE
allow hyphens in gene names in GRRs`:

### DIFF
--- a/src/base/utils/gene_associations.jl
+++ b/src/base/utils/gene_associations.jl
@@ -62,7 +62,7 @@ function _parse_grr_to_sbml(str::String)::Maybe{SBML.GeneProductAssociation}
     toks = String[]
     m = Nothing
     while !isnothing(begin
-        m = match(r"( +|[a-zA-Z0-9_]+|[^ a-zA-Z0-9_()]+|[(]|[)])(.*)", s)
+        m = match(r"( +|[a-zA-Z0-9_-]+|[^ a-zA-Z0-9_()-]+|[(]|[)])(.*)", s)
     end)
         tok = strip(m.captures[1])
         !isempty(tok) && push!(toks, tok)


### PR DESCRIPTION
(as seen e.g. in https://doi.org/10.1186/1752-0509-6-55 )
