### PR TITLE
remove lots of lb/ub shortcuts from API

### DIFF
--- a/src/analysis/flux_variability_analysis.jl
+++ b/src/analysis/flux_variability_analysis.jl
@@ -144,8 +144,8 @@ mins, maxs = flux_variability_analysis_dict(
     bounds = objective_bounds(0.99),
     modifications = [
         change_optimizer_attribute("IPM_IterationsLimit", 500),
-        change_constraint("EX_glc__D_e"; lb = -10, ub = -10),
-        change_constraint("EX_o2_e"; lb = 0, ub = 0),
+        change_constraint("EX_glc__D_e"; lower_bound = -10, upper_bound = -10),
+        change_constraint("EX_o2_e"; lower_bound = 0, upper_bound = 0),
     ],
 )
 ```

--- a/src/analysis/minimize_metabolic_adjustment.jl
+++ b/src/analysis/minimize_metabolic_adjustment.jl
@@ -27,7 +27,7 @@ optmodel = minimize_metabolic_adjustment(
     model,
     flux_ref,
     Gurobi.Optimizer;
-    modifications = [change_constraint("PFL"; lb=0, ub=0)], # find flux of mutant that is closest to the wild type (reference) model
+    modifications = [change_constraint("PFL"; lower_bound=0, upper_bound=0)], # find flux of mutant that is closest to the wild type (reference) model
     )
 value.(solution[:x])  # extract the flux from the optimizer
 ```

--- a/src/analysis/modifications/generic.jl
+++ b/src/analysis/modifications/generic.jl
@@ -15,13 +15,13 @@ constrain_objective_value(tolerance) =
 """
 $(TYPEDSIGNATURES)
 
-Change the lower and upper bounds (`lb` and `ub` respectively) of reaction `id` if supplied.
+Change the lower and upper bounds (`lower_bound` and `upper_bound` respectively) of reaction `id` if supplied.
 """
-change_constraint(id::String; lb = nothing, ub = nothing) =
+change_constraint(id::String; lower_bound = nothing, upper_bound = nothing) =
     (model, opt_model) -> begin
         ind = first(indexin([id], reactions(model)))
         isnothing(ind) && throw(DomainError(id, "No matching reaction was found."))
-        set_optmodel_bound!(ind, opt_model, lb = lb, ub = ub)
+        set_optmodel_bound!(ind, opt_model, lower = lower_bound, upper = upper_bound)
     end
 
 """

--- a/src/analysis/modifications/knockout.jl
+++ b/src/analysis/modifications/knockout.jl
@@ -38,7 +38,7 @@ function _do_knockout(model::MetabolicModel, opt_model, gene_ids::Vector{String}
         rga = reaction_gene_association(model, rxn_id)
         if !isnothing(rga) &&
            all([any(in.(gene_ids, Ref(conjunction))) for conjunction in rga])
-            set_optmodel_bound!(rxn_num, opt_model, ub = 0, lb = 0)
+            set_optmodel_bound!(rxn_num, opt_model, lower = 0, upper = 0)
         end
     end
 end

--- a/src/base/solver.jl
+++ b/src/base/solver.jl
@@ -73,11 +73,11 @@ not be changed.
 function set_optmodel_bound!(
     vidx,
     opt_model;
-    lb::Maybe{Real} = nothing,
-    ub::Maybe{Real} = nothing,
+    lower::Maybe{Real} = nothing,
+    upper::Maybe{Real} = nothing,
 )
-    isnothing(lb) || set_normalized_rhs(opt_model[:lbs][vidx], -lb)
-    isnothing(ub) || set_normalized_rhs(opt_model[:ubs][vidx], ub)
+    isnothing(lower) || set_normalized_rhs(opt_model[:lbs][vidx], -lower)
+    isnothing(upper) || set_normalized_rhs(opt_model[:ubs][vidx], upper)
 end
 
 """

--- a/src/base/types/Reaction.jl
+++ b/src/base/types/Reaction.jl
@@ -10,8 +10,8 @@ mutable struct Reaction
     id::String
     name::Maybe{String}
     metabolites::Dict{String,Float64}
-    lb::Float64
-    ub::Float64
+    lower_bound::Float64
+    upper_bound::Float64
     grr::Maybe{GeneAssociation}
     subsystem::Maybe{String}
     notes::Notes
@@ -30,8 +30,8 @@ function Reaction(
     id = "";
     name = nothing,
     metabolites = Dict{String,Float64}(),
-    lb = -_constants.default_reaction_bound,
-    ub = _constants.default_reaction_bound,
+    lower_bound = -_constants.default_reaction_bound,
+    upper_bound = _constants.default_reaction_bound,
     grr = nothing,
     subsystem = nothing,
     notes = Notes(),
@@ -43,8 +43,8 @@ function Reaction(
         id,
         name,
         mets,
-        lb,
-        ub,
+        lower_bound,
+        upper_bound,
         grr,
         subsystem,
         notes,
@@ -70,16 +70,21 @@ function Reaction(
     default_bound = _constants.default_reaction_bound,
 )
     if dir == :forward
-        lb = 0.0
-        ub = default_bound
+        lower_bound = 0.0
+        upper_bound = default_bound
     elseif dir == :reverse
-        lb = -default_bound
-        ub = 0.0
+        lower_bound = -default_bound
+        upper_bound = 0.0
     elseif dir == :bidirectional
-        lb = -default_bound
-        ub = default_bound
+        lower_bound = -default_bound
+        upper_bound = default_bound
     else
         throw(DomainError(dir, "unsupported direction"))
     end
-    Reaction(id; metabolites = metabolites, lb = lb, ub = ub)
+    Reaction(
+        id;
+        metabolites = metabolites,
+        lower_bound = lower_bound,
+        upper_bound = upper_bound,
+    )
 end

--- a/src/base/types/StandardModel.jl
+++ b/src/base/types/StandardModel.jl
@@ -144,7 +144,7 @@ $(TYPEDSIGNATURES)
 Return the lower bounds for all reactions in `model` in sparse format.
 """
 lower_bounds(model::StandardModel)::Vector{Float64} =
-    sparse([model.reactions[rxn].lb for rxn in reactions(model)])
+    sparse([model.reactions[rxn].lower_bound for rxn in reactions(model)])
 
 """
 $(TYPEDSIGNATURES)
@@ -153,7 +153,7 @@ Return the upper bounds for all reactions in `model` in sparse format.
 Order matches that of the reaction ids returned in `reactions()`.
 """
 upper_bounds(model::StandardModel)::Vector{Float64} =
-    sparse([model.reactions[rxn].ub for rxn in reactions(model)])
+    sparse([model.reactions[rxn].upper_bound for rxn in reactions(model)])
 
 """
 $(TYPEDSIGNATURES)
@@ -360,8 +360,8 @@ function Base.convert(::Type{StandardModel}, model::MetabolicModel)
             rid;
             name = reaction_name(model, rid),
             metabolites = rmets,
-            lb = lbs[i],
-            ub = ubs[i],
+            lower_bound = lbs[i],
+            upper_bound = ubs[i],
             grr = reaction_gene_association(model, rid),
             objective_coefficient = ocs[i],
             notes = reaction_notes(model, rid),

--- a/src/base/utils/StandardModel.jl
+++ b/src/base/utils/StandardModel.jl
@@ -19,8 +19,8 @@ Shallow copy of a [`Reaction`](@ref)
 Base.copy(r::Reaction) = Reaction(
     r.id;
     metabolites = r.metabolites,
-    lb = r.lb,
-    ub = r.ub,
+    lower_bound = r.lower_bound,
+    upper_bound = r.upper_bound,
     grr = r.grr,
     subsystem = r.subsystem,
     notes = r.notes,

--- a/src/io/show/Reaction.jl
+++ b/src/io/show/Reaction.jl
@@ -15,11 +15,11 @@ function _pretty_substances(ss::Vector{String})::String
 end
 
 function Base.show(io::IO, ::MIME"text/plain", r::Reaction)
-    if r.ub > 0.0 && r.lb < 0.0
+    if r.upper_bound > 0.0 && r.lower_bound < 0.0
         arrow = " ↔  "
-    elseif r.ub <= 0.0 && r.lb < 0.0
+    elseif r.upper_bound <= 0.0 && r.lower_bound < 0.0
         arrow = " ←  "
-    elseif r.ub > 0.0 && r.lb >= 0.0
+    elseif r.upper_bound > 0.0 && r.lower_bound >= 0.0
         arrow = " →  "
     else
         arrow = " →|←  " # blocked reaction
@@ -42,7 +42,7 @@ function Base.show(io::IO, ::MIME"text/plain", r::Reaction)
                 "Reaction.$(string(fname)): ",
                 _maybemap(x -> _unparse_grr(String, x), r.grr),
             )
-        elseif fname in (:lb, :ub, :objective_coefficient)
+        elseif fname in (:lower_bound, :upper_bound, :objective_coefficient)
             _pretty_print_keyvals(
                 io,
                 "Reaction.$(string(fname)): ",

--- a/src/reconstruction/CoreModel.jl
+++ b/src/reconstruction/CoreModel.jl
@@ -19,8 +19,8 @@ function add_reactions!(model::CoreModel, rxns::Vector{Reaction})
             push!(V, v)
         end
         push!(model.rxns, rxn.id)
-        lbs[j] = rxn.lb
-        ubs[j] = rxn.ub
+        lbs[j] = rxn.lower_bound
+        ubs[j] = rxn.upper_bound
         cs[j] = rxn.objective_coefficient
     end
     Sadd = sparse(I, J, V, n_metabolites(model), length(rxns))

--- a/src/reconstruction/StandardModel.jl
+++ b/src/reconstruction/StandardModel.jl
@@ -97,12 +97,12 @@ macro add_reactions!(model::Symbol, ex::Expr)
         push!(all_reactions.args, :(r.id = $id))
         if length(args) == 3
             lb = args[3]
-            push!(all_reactions.args, :(r.lb = $lb))
+            push!(all_reactions.args, :(r.lower_bound = $lb))
         elseif length(args) == 4
             lb = args[3]
             ub = args[4]
-            push!(all_reactions.args, :(r.lb = $lb))
-            push!(all_reactions.args, :(r.ub = $ub))
+            push!(all_reactions.args, :(r.lower_bound = $lb))
+            push!(all_reactions.args, :(r.upper_bound = $ub))
         end
         push!(all_reactions.args, :(add_reaction!($model, r)))
     end

--- a/src/reconstruction/StandardModel.jl
+++ b/src/reconstruction/StandardModel.jl
@@ -155,8 +155,8 @@ remove_gene!(model::StandardModel, gid::String; knockout_reactions::Bool = false
 
 
 @_change_bounds_fn StandardModel String inplace begin
-    isnothing(lower) || (model.reactions[rxn_id].lb = lower)
-    isnothing(upper) || (model.reactions[rxn_id].ub = upper)
+    isnothing(lower) || (model.reactions[rxn_id].lower_bound = lower)
+    isnothing(upper) || (model.reactions[rxn_id].upper_bound = upper)
     nothing
 end
 

--- a/src/reconstruction/community.jl
+++ b/src/reconstruction/community.jl
@@ -52,8 +52,8 @@ function add_community_objective!(
     rdict = Dict(k => -float(v) for (k, v) in objective_mets_weights)
     rxn = Reaction(objective_id)
     rxn.metabolites = rdict
-    rxn.lb = 0.0
-    rxn.ub = _constants.default_reaction_bound
+    rxn.lower_bound = 0.0
+    rxn.upper_bound = _constants.default_reaction_bound
     rxn.objective_coefficient = 1.0
     community.reactions[rxn.id] = rxn
 
@@ -347,8 +347,8 @@ function join_with_exchanges(
     for (rid, mid) in exchange_rxn_mets
         community.reactions[rid] = Reaction(rid)
         community.reactions[rid].metabolites = Dict{String,Float64}(mid => -1.0)
-        community.reactions[rid].lb = 0.0
-        community.reactions[rid].ub = 0.0
+        community.reactions[rid].lower_bound = 0.0
+        community.reactions[rid].upper_bound = 0.0
         community.metabolites[mid] = Metabolite(mid)
         community.metabolites[mid].id = mid
     end

--- a/src/reconstruction/gapfill_minimum_reactions.jl
+++ b/src/reconstruction/gapfill_minimum_reactions.jl
@@ -203,8 +203,8 @@ function _universal_stoichiometry(urxns::Vector{Reaction}, mids::Vector{String})
                 length(urxns),
             ),
         ),
-        lbs = [rxn.lb for rxn in urxns],
-        ubs = [rxn.ub for rxn in urxns],
+        lbs = [rxn.lower_bound for rxn in urxns],
+        ubs = [rxn.upper_bound for rxn in urxns],
         new_mids = new_mids,
     )
 end

--- a/test/analysis/fba_with_crowding.jl
+++ b/test/analysis/fba_with_crowding.jl
@@ -11,7 +11,7 @@
         modifications = [
             change_optimizer_attribute("IPM_IterationsLimit", 1000),
             add_crowding_constraints(rid_weight),
-            change_constraint("EX_glc__D_e"; lb = -6),
+            change_constraint("EX_glc__D_e"; lower_bound = -6),
         ],
     )
 

--- a/test/analysis/flux_balance_analysis.jl
+++ b/test/analysis/flux_balance_analysis.jl
@@ -39,7 +39,7 @@ end
         Tulip.Optimizer;
         modifications = [
             change_objective("BIOMASS_Ecoli_core_w_GAM"),
-            change_constraint("EX_glc__D_e"; lb = -12, ub = -12),
+            change_constraint("EX_glc__D_e"; lower_bound = -12, upper_bound = -12),
             change_sense(MAX_SENSE),
             change_optimizer_attribute("IPM_IterationsLimit", 110),
         ],
@@ -71,7 +71,7 @@ end
     @test_throws DomainError flux_balance_analysis_dict(
         model,
         Tulip.Optimizer;
-        modifications = [change_constraint("gbbrsh"; lb = -12, ub = -12)],
+        modifications = [change_constraint("gbbrsh"; lower_bound = -12, upper_bound = -12)],
     )
     @test_throws DomainError flux_balance_analysis_dict(
         model,

--- a/test/analysis/flux_variability_analysis.jl
+++ b/test/analysis/flux_variability_analysis.jl
@@ -85,8 +85,8 @@ end
         bounds = objective_bounds(0.99),
         modifications = [
             change_optimizer_attribute("IPM_IterationsLimit", 500),
-            change_constraint("EX_glc__D_e"; lb = -10, ub = -10),
-            change_constraint("EX_o2_e"; lb = 0.0, ub = 0.0),
+            change_constraint("EX_glc__D_e"; lower_bound = -10, upper_bound = -10),
+            change_constraint("EX_o2_e"; lower_bound = 0.0, upper_bound = 0.0),
         ],
     )
 

--- a/test/analysis/gecko.jl
+++ b/test/analysis/gecko.jl
@@ -58,7 +58,7 @@
         Tulip.Optimizer;
         modifications = [
             change_objective(genes(gm); weights = [], sense = COBREXA.MIN_SENSE),
-            change_constraint("BIOMASS_Ecoli_core_w_GAM", lb = growth_lb),
+            change_constraint("BIOMASS_Ecoli_core_w_GAM", lower_bound = growth_lb),
             change_optimizer_attribute("IPM_IterationsLimit", 1000),
         ],
     )

--- a/test/analysis/knockouts.jl
+++ b/test/analysis/knockouts.jl
@@ -104,7 +104,7 @@ end
             Tulip.Optimizer;
             modifications = [
                 change_objective("BIOMASS_Ecoli_core_w_GAM"),
-                change_constraint("EX_glc__D_e"; lb = -12, ub = -12),
+                change_constraint("EX_glc__D_e"; lower_bound = -12, upper_bound = -12),
                 change_sense(MAX_SENSE),
                 change_optimizer_attribute("IPM_IterationsLimit", 110),
                 knockout(["b0978", "b0734"]), # knockouts out cytbd
@@ -121,7 +121,7 @@ end
             Tulip.Optimizer;
             modifications = [
                 change_objective("BIOMASS_Ecoli_core_w_GAM"),
-                change_constraint("EX_glc__D_e"; lb = -12, ub = -12),
+                change_constraint("EX_glc__D_e"; lower_bound = -12, upper_bound = -12),
                 change_sense(MAX_SENSE),
                 change_optimizer_attribute("IPM_IterationsLimit", 110),
                 knockout("b2779"), # knockouts out enolase

--- a/test/analysis/moment.jl
+++ b/test/analysis/moment.jl
@@ -9,7 +9,7 @@
         Tulip.Optimizer;
         modifications = [
             add_moment_constraints(ksas, protein_mass_fraction;),
-            change_constraint("EX_glc__D_e", lb = -1000),
+            change_constraint("EX_glc__D_e", lower_bound = -1000),
         ],
     )
 

--- a/test/analysis/parsimonious_flux_balance_analysis.jl
+++ b/test/analysis/parsimonious_flux_balance_analysis.jl
@@ -5,7 +5,7 @@
         model,
         Tulip.Optimizer;
         modifications = [
-            change_constraint("EX_m1(e)", lb = -10.0),
+            change_constraint("EX_m1(e)", lower_bound = -10.0),
             change_optimizer_attribute("IPM_IterationsLimit", 500),
         ],
         qp_modifications = [change_optimizer(Clarabel.Optimizer), silence],

--- a/test/base/types/Reaction.jl
+++ b/test/base/types/Reaction.jl
@@ -21,8 +21,8 @@
     r1 = Reaction()
     r1.id = "r1"
     r1.metabolites = Dict(m1.id => -1.0, m2.id => 1.0)
-    r1.lb = -100.0
-    r1.ub = 100.0
+    r1.lower_bound = -100.0
+    r1.upper_bound = 100.0
     r1.grr = [["g1", "g2"], ["g3"]]
     r1.subsystem = "glycolysis"
     r1.notes = Dict("notes" => ["blah", "blah"])
@@ -77,14 +77,14 @@
     @test occursin("...", sprint(show, MIME("text/plain"), rlongrev))
 
     r2 = Reaction("r2", Dict(m1.id => -2.0, m4.id => 1.0), :reverse)
-    @test r2.lb == -1000.0 && r2.ub == 0.0
+    @test r2.lower_bound == -1000.0 && r2.upper_bound == 0.0
 
     r3 = Reaction("r3", Dict(m3.id => -1.0, m4.id => 1.0), :forward)
-    @test r3.lb == 0.0 && r3.ub == 1000.0
+    @test r3.lower_bound == 0.0 && r3.upper_bound == 1000.0
 
     r4 = Reaction("r4", Dict(m3.id => -1.0, m4.id => 1.0), :bidirectional)
     r4.annotations = Dict("sboterm" => ["sbo"], "biocyc" => ["ads", "asds"])
-    @test r4.lb == -1000.0 && r4.ub == 1000.0
+    @test r4.lower_bound == -1000.0 && r4.upper_bound == 1000.0
 
     rd = OrderedDict(r.id => r for r in [r1, r2, r3, r4])
     @test issetequal(["r1", "r4"], ambiguously_identified_items(annotation_index(rd)))

--- a/test/base/types/StandardModel.jl
+++ b/test/base/types/StandardModel.jl
@@ -20,8 +20,8 @@
     r1 = Reaction()
     r1.id = "r1"
     r1.metabolites = Dict(m1.id => -1.0, m2.id => 1.0)
-    r1.lb = -100.0
-    r1.ub = 100.0
+    r1.lower_bound = -100.0
+    r1.upper_bound = 100.0
     r1.grr = [["g1", "g2"], ["g3"]]
     r1.subsystem = "glycolysis"
     r1.notes = Dict("notes" => ["blah", "blah"])

--- a/test/base/utils/StandardModel.jl
+++ b/test/base/utils/StandardModel.jl
@@ -15,10 +15,10 @@
     glucose_index = first(indexin(["EX_glc__D_e"], reactions(model)))
     o2_index = first(indexin(["EX_o2_e"], reactions(model)))
     atpm_index = first(indexin(["ATPM"], reactions(model)))
-    set_optmodel_bound!(glucose_index, cbm; ub = -1.0, lb = -1.0)
+    set_optmodel_bound!(glucose_index, cbm; upper = -1.0, lower = -1.0)
     @test normalized_rhs(ubs[glucose_index]) == -1.0
     @test normalized_rhs(lbs[glucose_index]) == 1.0
-    set_optmodel_bound!(o2_index, cbm; ub = 1.0, lb = 1.0)
+    set_optmodel_bound!(o2_index, cbm; upper = 1.0, lower = 1.0)
     @test normalized_rhs(ubs[o2_index]) == 1.0
     @test normalized_rhs(lbs[o2_index]) == -1.0
 end

--- a/test/reconstruction/CoreModel.jl
+++ b/test/reconstruction/CoreModel.jl
@@ -236,7 +236,7 @@ end
     rxn1 = Reaction("nr1"; metabolites = Dict("m1[c]" => -1, "m3[c]" => 1))
     rxn2 = Reaction("nr2"; metabolites = Dict("m1[c]" => -1, "m2[c]" => 1))
     rxn3 = Reaction("nr3"; metabolites = Dict("m2[c]" => -1, "m3[c]" => 1))
-    rxn3.lb = 10
+    rxn3.lower_bound = 10
 
     add_reaction!(toymodel, rxn1)
     @test toymodel.S[1, 8] == -1

--- a/test/reconstruction/Reaction.jl
+++ b/test/reconstruction/Reaction.jl
@@ -10,13 +10,13 @@
     h_p = model.metabolites["h_p"]
 
     rxn = nadh + 4.0 * h_c + 1.0 * q8 → 1.0 * q8h2 + 1.0 * nad + 3.0 * h_p
-    @test rxn.lb == 0.0 && rxn.ub > 0.0
+    @test rxn.lower_bound == 0.0 && rxn.upper_bound > 0.0
 
     rxn = 1.0 * nadh + 4.0 * h_c + q8 ← 1.0 * q8h2 + 1.0 * nad + 3.0 * h_p
-    @test rxn.lb < 0.0 && rxn.ub == 0.0
+    @test rxn.lower_bound < 0.0 && rxn.upper_bound == 0.0
 
     rxn = 1.0 * nadh + 4.0 * h_c + 1.0 * q8 ↔ q8h2 + nad + 3.0 * h_p
-    @test rxn.lb < 0.0 && rxn.ub > 0.0
+    @test rxn.lower_bound < 0.0 && rxn.upper_bound > 0.0
 
     rxn = 1.0 * nadh → nothing
     @test length(rxn.metabolites) == 1
@@ -32,5 +32,5 @@
     @test ("q8h2_c" in [x for x in keys(rxn.metabolites)])
 
     rxn = nadh + 4.0 * h_c + 1.0 * q8 → 1.0 * q8h2 + 1.0 * nad + 3.0 * h_p
-    @test rxn.lb == 0.0 && rxn.ub > 0.0
+    @test rxn.lower_bound == 0.0 && rxn.upper_bound > 0.0
 end

--- a/test/reconstruction/StandardModel.jl
+++ b/test/reconstruction/StandardModel.jl
@@ -34,42 +34,42 @@
 
     # change bound tests - in place
     change_bound!(model, "r2"; lower = -10, upper = 10)
-    @test model.reactions["r2"].lb == -10
-    @test model.reactions["r2"].ub == 10
+    @test model.reactions["r2"].lower_bound == -10
+    @test model.reactions["r2"].upper_bound == 10
     change_bound!(model, "r2"; lower = -100)
-    @test model.reactions["r2"].lb == -100
-    @test model.reactions["r2"].ub == 10
+    @test model.reactions["r2"].lower_bound == -100
+    @test model.reactions["r2"].upper_bound == 10
     change_bound!(model, "r2"; upper = 111)
-    @test model.reactions["r2"].lb == -100
-    @test model.reactions["r2"].ub == 111
+    @test model.reactions["r2"].lower_bound == -100
+    @test model.reactions["r2"].upper_bound == 111
 
     change_bounds!(model, ["r1", "r2"]; lower = [-110, -220], upper = [110.0, 220.0])
-    @test model.reactions["r1"].lb == -110
-    @test model.reactions["r1"].ub == 110
-    @test model.reactions["r2"].lb == -220
-    @test model.reactions["r2"].ub == 220
+    @test model.reactions["r1"].lower_bound == -110
+    @test model.reactions["r1"].upper_bound == 110
+    @test model.reactions["r2"].lower_bound == -220
+    @test model.reactions["r2"].upper_bound == 220
 
     # change bound - new model
     new_model = change_bound(model, "r2"; lower = -10, upper = 10)
-    @test new_model.reactions["r2"].lb == -10
-    @test new_model.reactions["r2"].ub == 10
+    @test new_model.reactions["r2"].lower_bound == -10
+    @test new_model.reactions["r2"].upper_bound == 10
 
     new_model = change_bound(model, "r2"; lower = -10)
-    @test new_model.reactions["r2"].lb == -10
-    @test new_model.reactions["r2"].ub == 220
+    @test new_model.reactions["r2"].lower_bound == -10
+    @test new_model.reactions["r2"].upper_bound == 220
 
     new_model = change_bounds(model, ["r1", "r2"]; lower = [-10, -20], upper = [10.0, 20.0])
-    @test new_model.reactions["r1"].lb == -10
-    @test new_model.reactions["r1"].ub == 10
-    @test new_model.reactions["r2"].lb == -20
-    @test new_model.reactions["r2"].ub == 20
+    @test new_model.reactions["r1"].lower_bound == -10
+    @test new_model.reactions["r1"].upper_bound == 10
+    @test new_model.reactions["r2"].lower_bound == -20
+    @test new_model.reactions["r2"].upper_bound == 20
 
     new_model =
         change_bounds(model, ["r1", "r2"]; lower = [-10, nothing], upper = [nothing, 20.0])
-    @test new_model.reactions["r1"].lb == -10
-    @test new_model.reactions["r1"].ub == 110
-    @test new_model.reactions["r2"].lb == -220
-    @test new_model.reactions["r2"].ub == 20
+    @test new_model.reactions["r1"].lower_bound == -10
+    @test new_model.reactions["r1"].upper_bound == 110
+    @test new_model.reactions["r2"].lower_bound == -220
+    @test new_model.reactions["r2"].upper_bound == 20
 
     ### reactions
     add_reactions!(model, [r3, r4])

--- a/test/reconstruction/add_reactions.jl
+++ b/test/reconstruction/add_reactions.jl
@@ -12,14 +12,14 @@
     end
 
     rxn = mod.reactions["v1"]
-    @test rxn.lb == -1000.0
-    @test rxn.ub == 1000.0
+    @test rxn.lower_bound == -1000.0
+    @test rxn.upper_bound == 1000.0
 
     rxn = mod.reactions["v2"]
-    @test rxn.lb == -500
-    @test rxn.ub == 1000.0
+    @test rxn.lower_bound == -500
+    @test rxn.upper_bound == 1000.0
 
     rxn = mod.reactions["v3"]
-    @test rxn.lb == -500
-    @test rxn.ub == 500
+    @test rxn.lower_bound == -500
+    @test rxn.upper_bound == 500
 end

--- a/test/reconstruction/community.jl
+++ b/test/reconstruction/community.jl
@@ -20,9 +20,9 @@
     # test if environmental exchanges have been added properly
     @test c1.S[13, 15] == c1.S[14, 16] == -1
     # test of bounds set properly
-    lb, ub = bounds(c1)
-    @test all(lb[1:14] .== -ub[1:14] .== -1000)
-    @test all(lb[15:16] .== -ub[15:16] .== 0.0)
+    lower_bound, upper_bound = bounds(c1)
+    @test all(lower_bound[1:14] .== -upper_bound[1:14] .== -1000)
+    @test all(lower_bound[15:16] .== -upper_bound[15:16] .== 0.0)
 
     add_community_objective!(
         c1,
@@ -202,9 +202,9 @@ end
     @test c1.reactions["species_2_EX_m3(e)"].metabolites["species_2_m3[e]"] == 1
 
     # test of bounds set properly
-    lb, ub = bounds(c1) # this only works because the insertion order is preserved (they get added last)
-    @test all(lb[1:14] .== -ub[1:14] .== -1000)
-    @test all(lb[15:16] .== -ub[15:16] .== 0.0)
+    lower_bound, upper_bound = bounds(c1) # this only works because the insertion order is preserved (they get added last)
+    @test all(lower_bound[1:14] .== -upper_bound[1:14] .== -1000)
+    @test all(lower_bound[15:16] .== -upper_bound[15:16] .== 0.0)
 
     add_community_objective!(
         c1,
@@ -243,8 +243,8 @@ end
     )
 
     for rid in keys(exchange_rxn_mets)
-        c.reactions[rid].lb = m1.reactions[rid].lb
-        c.reactions[rid].ub = m1.reactions[rid].ub
+        c.reactions[rid].lower_bound = m1.reactions[rid].lower_bound
+        c.reactions[rid].upper_bound = m1.reactions[rid].upper_bound
     end
 
     @test c.reactions["species_1_BIOMASS_Ecoli_core_w_GAM"].metabolites["species_1_BIOMASS_Ecoli_core_w_GAM"] ==


### PR DESCRIPTION
Closes #623 

This is breaking, do not merge until we are sure that 2.0 is going to be released next.

We might possibly also remove `grr` and other shortcuts.