### PR TITLE
genetic manipulation wrappers

### DIFF
--- a/docs/src/examples/05b_fba_mods.jl
+++ b/docs/src/examples/05b_fba_mods.jl
@@ -30,7 +30,7 @@ fluxes = flux_balance_analysis_dict(
     modifications = [ # modifications are applied in order
         change_objective("R_BIOMASS_Ecoli_core_w_GAM"), # maximize production
         change_constraint("R_EX_glc__D_e"; lb = -12, ub = -12), # fix an exchange rate
-        knockout(["b0978", "b0734"]), # knock out two genes
+        add_knockout_constraints(["b0978", "b0734"]), # knock out two genes
         change_optimizer(Tulip.Optimizer), # ignore the above optimizer and switch to Tulip
         change_optimizer_attribute("IPM_IterationsLimit", 1000), # customize Tulip
         change_sense(MAX_SENSE), # explicitly tell Tulip to maximize the objective

--- a/docs/src/examples/07_gene_deletion.jl
+++ b/docs/src/examples/07_gene_deletion.jl
@@ -1,8 +1,8 @@
 # # Gene knockouts
 
-# Here we will use the [`knockout`](@ref) function to modify the optimization
+# Here we will use the [`add_knockout_constraints`](@ref) function to modify the optimization
 # model before solving, in order to simulate genes knocked out. We can pass
-# [`knockout`](@ref) to many analysis functions that support parameter
+# [`add_knockout_constraints`](@ref) to many analysis functions that support parameter
 # `modifications`, including [`flux_balance_analysis`](@ref),
 # [`flux_variability_analysis`](@ref), and others.
 
@@ -25,8 +25,11 @@ genes(model)
 sort(gene_name.(Ref(model), genes(model)) .=> genes(model))
 
 # Compute the flux with a genes knocked out:
-flux_with_knockout =
-    flux_balance_analysis_dict(model, GLPK.Optimizer, modifications = [knockout("G_b3236")])
+flux_with_knockout = flux_balance_analysis_dict(
+    model,
+    GLPK.Optimizer,
+    modifications = [add_knockout_constraints("G_b3236")],
+)
 
 # We can see there is a small decrease in production upon knocking out the gene:
 biomass_id = "R_BIOMASS_Ecoli_core_w_GAM"
@@ -34,8 +37,11 @@ flux_with_knockout[biomass_id] / original_flux[biomass_id]
 
 # Similarly, we can explore how the flux variability has changed once the gene
 # is knocked out:
-variability_with_knockout =
-    flux_variability_analysis(model, GLPK.Optimizer, modifications = [knockout("G_b3236")])
+variability_with_knockout = flux_variability_analysis(
+    model,
+    GLPK.Optimizer,
+    modifications = [add_knockout_constraints("G_b3236")],
+)
 
 # ## Knocking out multiple genes
 
@@ -48,7 +54,7 @@ reaction_gene_association(model, "R_FBA")
 flux_with_double_knockout = flux_balance_analysis_dict(
     model,
     GLPK.Optimizer,
-    modifications = [knockout(["G_b2097", "G_b1773", "G_b2925"])],
+    modifications = [add_knockout_constraints(["G_b2097", "G_b1773", "G_b2925"])],
 )
 #
 flux_with_double_knockout[biomass_id] / original_flux[biomass_id]
@@ -62,7 +68,11 @@ knockout_fluxes = screen(
     model,
     args = tuple.(genes(model)),
     analysis = (m, gene) -> begin
-        res = flux_balance_analysis_dict(m, GLPK.Optimizer, modifications = [knockout(gene)])
+        res = flux_balance_analysis_dict(
+            m,
+            GLPK.Optimizer,
+            modifications = [add_knockout_constraints(gene)],
+        )
         if !isnothing(res)
             res[biomass_id]
         end
@@ -90,7 +100,7 @@ double_knockout_fluxes = screen(
         res = flux_balance_analysis_dict(
             m,
             GLPK.Optimizer,
-            modifications = [knockout(gene_groups)],
+            modifications = [add_knockout_constraints(gene_groups)],
         )
         if !isnothing(res)
             res[biomass_id]

--- a/src/analysis/modifications/knockout.jl
+++ b/src/analysis/modifications/knockout.jl
@@ -1,5 +1,5 @@
 """
-    knockout(gene_ids::Vector{String})
+    add_knockout_constraints(gene_ids::Vector{String})
 
 A modification that zeroes the bounds of all reactions that would be knocked
 out by the combination of specified genes (effectively disabling the
@@ -7,33 +7,37 @@ reactions).
 
 A slightly counter-intuitive behavior may occur if knocking out multiple genes:
 Because this only changes the reaction bounds, multiple gene knockouts _must_
-be specified in a single call to [`knockout`](@ref), because the modifications
+be specified in a single call to [`add_knockout_constraints`](@ref), because the modifications
 have no way to remember which genes are already knocked out and which not.
 
 In turn, having a reaction that can be catalyzed either by Gene1 or by Gene2,
-specifying `modifications = [knockout(["Gene1", "Gene2"])]` does indeed disable
-the reaction, but `modifications = [knockout("Gene1"), knockout("Gene2")]` does
+specifying `modifications = [add_knockout_constraints(["Gene1", "Gene2"])]` does indeed disable
+the reaction, but `modifications = [add_knockout_constraints("Gene1"), add_knockout_constraints("Gene2")]` does
 _not_ disable the reaction (although reactions that depend either only on Gene1
 or only on Gene2 are disabled).
 """
-knockout(gene_ids::Vector{String}) =
-    (model, optmodel) -> _do_knockout(model, optmodel, gene_ids)
+add_knockout_constraints(gene_ids::Vector{String}) =
+    (model, optmodel) -> _do_knockout_constraints(model, optmodel, gene_ids)
 
 """
-    knockout(gene_id::String)
+    add_knockout_constraints(gene_id::String)
 
-A helper variant of [`knockout`](@ref) for a single gene.
+A helper variant of [`add_knockout_constraints`](@ref) for a single gene.
 """
-knockout(gene_id::String) = knockout([gene_id])
+add_knockout_constraints(gene_id::String) = add_knockout_constraints([gene_id])
 
 """
     _do_knockout(model::MetabolicModel, opt_model)
 
 Internal helper for knockouts on generic MetabolicModels. This can be
-overloaded so that the knockouts may work differently (more efficiently) with
-other models.
+overloaded so that the knockouts may work differently (perhaps more
+efficiently) with other model types.
 """
-function _do_knockout(model::MetabolicModel, opt_model, gene_ids::Vector{String})
+function _do_knockout_constraints(
+    model::MetabolicModel,
+    opt_model,
+    gene_ids::Vector{String},
+)
     for (rxn_num, rxn_id) in enumerate(reactions(model))
         rga = reaction_gene_association(model, rxn_id)
         if !isnothing(rga) &&

--- a/test/analysis/knockouts.jl
+++ b/test/analysis/knockouts.jl
@@ -1,4 +1,4 @@
-@testset "single_knockout" begin
+@testset "single knockout" begin
     m = StandardModel()
     add_metabolite!(m, Metabolite("A"))
     add_metabolite!(m, Metabolite("B"))
@@ -27,7 +27,7 @@
     )
 
     opt_model = make_optimization_model(m, Tulip.Optimizer)
-    knockout("g1")(m, opt_model)
+    add_knockout_constraints("g1")(m, opt_model)
 
     # Knockout should remove v1
     @test normalized_rhs(opt_model[:lbs][1]) == 0
@@ -46,7 +46,7 @@
     @test normalized_rhs(opt_model[:ubs][4]) == 1000
 end
 
-@testset "multiple_knockouts" begin
+@testset "multiple knockouts" begin
     m = StandardModel()
     add_metabolite!(m, Metabolite("A"))
     add_metabolite!(m, Metabolite("B"))
@@ -75,7 +75,7 @@ end
     )
 
     opt_model = make_optimization_model(m, Tulip.Optimizer)
-    knockout(["g1", "g3"])(m, opt_model)
+    add_knockout_constraints(["g1", "g3"])(m, opt_model)
 
     # Reaction 1 should be knocked out, because both
     # gene1 and gene 3 are knocked out
@@ -107,7 +107,7 @@ end
                 change_constraint("EX_glc__D_e"; lb = -12, ub = -12),
                 change_sense(MAX_SENSE),
                 change_optimizer_attribute("IPM_IterationsLimit", 110),
-                knockout(["b0978", "b0734"]), # knockouts out cytbd
+                add_knockout_constraints(["b0978", "b0734"]), # knockouts out cytbd
             ],
         )
         @test isapprox(
@@ -124,7 +124,7 @@ end
                 change_constraint("EX_glc__D_e"; lb = -12, ub = -12),
                 change_sense(MAX_SENSE),
                 change_optimizer_attribute("IPM_IterationsLimit", 110),
-                knockout("b2779"), # knockouts out enolase
+                add_knockout_constraints("b2779"), # knockouts out enolase
             ],
         )
         @test isapprox(sol["BIOMASS_Ecoli_core_w_GAM"], 0.0, atol = TEST_TOLERANCE)


### PR DESCRIPTION
## Description

This should subsume various functionality that was drafted previously but not merged (EFlux) and also a generic way to add knockouts to models.

Closes #552 . 
(eventually)

In the process, I'll break `knockout` to clean up the naming, so this really needs to go to 2.0. Which is otherwise not a big deal because the naming of stuff is going to get revamped there anyway.