### PR TITLE
hotfix: bump CompatHelper version to work with 1.8

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -12,7 +12,7 @@ jobs:
           import Pkg
           name = "CompatHelper"
           uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
-          version = "2"
+          version = "3"
           Pkg.add(; name, uuid, version)
         shell: julia --color=yes {0}
       - name: "Run CompatHelper"


### PR DESCRIPTION
Same issue and solution as with https://github.com/LCSB-BioCore/GigaSOM.jl/pull/206

For CI reasons I think merging right into master will be much better here (feel free to reparent if not).