### PR TITLE
Fix pFBA issue with return type nothing

### DIFF
--- a/src/analysis/parsimonious_flux_balance_analysis.jl
+++ b/src/analysis/parsimonious_flux_balance_analysis.jl
@@ -61,7 +61,7 @@ function parsimonious_flux_balance_analysis(
 )
     # Run FBA
     opt_model = flux_balance_analysis(model, optimizer; modifications = modifications)
-    is_solved(opt_model) || return nothing # FBA failed
+    is_solved(opt_model) || return opt_model # FBA failed
 
     # get the objective
     Z = objective_value(opt_model)
@@ -87,8 +87,6 @@ function parsimonious_flux_balance_analysis(
         delete(opt_model, pfba_constraint)
         unregister(opt_model, :pfba_constraint)
     end
-
-    is_solved(opt_model) || return nothing # pFBA failed
 
     return opt_model
 end

--- a/src/analysis/parsimonious_flux_balance_analysis.jl
+++ b/src/analysis/parsimonious_flux_balance_analysis.jl
@@ -36,14 +36,15 @@ finds a minimal total flux through the model that still satisfies the (slightly
 relaxed) optimum. This is done using a quadratic problem optimizer. If the
 original optimizer does not support quadratic optimization, it can be changed
 using the callback in `qp_modifications`, which are applied after the FBA. See
-the documentation of [`flux_balance_analysis`](@ref) for usage examples of modifications.
+the documentation of [`flux_balance_analysis`](@ref) for usage examples of
+modifications.
 
 Thhe optimum relaxation sequence can be specified in `relax` parameter, it
-defaults to multiplicative range of `[1.0, 0.999999, ..., 0.99]` of the
-original bound.
+defaults to multiplicative range of `[1.0, 0.999999, ..., 0.99]` of the original
+bound.
 
-Returns an optimized model that contains the pFBA solution; or `nothing` if the
-optimization failed.
+Returns an optimized model that contains the pFBA solution (or an unsolved model
+if something went wrong).
 
 # Example
 ```


### PR DESCRIPTION
pFBA returns `nothing` prematurely. Both `flux_dict` and `flux_vector` expect an optimization model and return nothing if the model is not solved, we did this check prematurely. Closes #625 when complete.