### PR TITLE
switch tests julia from 1.7 to 1.8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,9 +70,9 @@ variables:
   before_script:
     - docker login -u $CI_USER_NAME -p $GITLAB_ACCESS_TOKEN $CI_REGISTRY
 
-.global_julia17: &global_julia17
+.global_julia18: &global_julia18
   variables:
-    JULIA_VER: "v1.7.0"
+    JULIA_VER: "v1.8.0"
 
 .global_julia16: &global_julia16
   variables:
@@ -119,7 +119,7 @@ variables:
 # any available docker and current julia
 #
 
-docker:julia1.7:
+docker:julia1.8:
   stage: test
   image: $CI_REGISTRY/r3/docker/julia-custom
   script:
@@ -133,12 +133,12 @@ docker:julia1.7:
 # built & deployed
 #
 
-linux:julia1.7:
+linux:julia1.8:
   stage: test
   tags:
     - slave01
   <<: *global_trigger_full_tests
-  <<: *global_julia17
+  <<: *global_julia18
   <<: *global_env_linux
 
 linux:julia1.6:
@@ -153,22 +153,22 @@ linux:julia1.6:
 # Additional platform&environment compatibility tests
 #
 
-windows8:julia1.7:
+windows8:julia1.8:
   stage: test-compat
   <<: *global_trigger_compat_tests
-  <<: *global_julia17
+  <<: *global_julia18
   <<: *global_env_win8
 
-windows10:julia1.7:
+windows10:julia1.8:
   stage: test-compat
   <<: *global_trigger_compat_tests
-  <<: *global_julia17
+  <<: *global_julia18
   <<: *global_env_win10
 
-mac:julia1.7:
+mac:julia1.8:
   stage: test-compat
   <<: *global_trigger_compat_tests
-  <<: *global_julia17
+  <<: *global_julia18
   <<: *global_env_mac
 
 windows8:julia1.6:
@@ -271,12 +271,12 @@ docker-release:
     - julia --project=@. -e 'import Pkg; Pkg.instantiate();'
     - julia --project=@. --color=yes test/doctests.jl
 
-doc-tests-pr:julia1.7:
+doc-tests-pr:julia1.8:
   stage: documentation
   <<: *global_doctests
   <<: *global_trigger_pull_request
 
-doc-tests:julia1.7:
+doc-tests:julia1.8:
   stage: test
   <<: *global_doctests
   <<: *global_trigger_full_tests


### PR DESCRIPTION
1.7 is old "stable" now; this should migrate the tests to LTS (1.6) + newest Julia (1.8)

I expect trouble though :sweat_smile: 