### PR TITLE
Rename reaction_gene_association to reaction_gene_associations

### DIFF
--- a/docs/src/examples/03b_accessors.jl
+++ b/docs/src/examples/03b_accessors.jl
@@ -35,7 +35,7 @@ variables(std)
 # - [`bounds`](@ref) return lower and upper bounds of reaction rates
 # - [`metabolite_charge`](@ref) and [`metabolite_formula`](@ref) return details about metabolites
 # - [`objective`](@ref) returns the objective of the model (usually labeled as `c`)
-# - [`reaction_gene_association`](@ref) describes the dependency of a reaction on gene products
+# - [`reaction_gene_associations`](@ref) describes the dependency of a reaction on gene products
 #
 # A complete, up-to-date list of accessors can be always generated using `methodswith`:
 

--- a/docs/src/examples/07_gene_deletion.jl
+++ b/docs/src/examples/07_gene_deletion.jl
@@ -43,7 +43,7 @@ variability_with_knockout =
 # knockout modification. This knocks out all genes that can run the FBA
 # reaction:
 
-reaction_gene_association(model, "R_FBA")
+reaction_gene_associations(model, "R_FBA")
 #
 flux_with_double_knockout = flux_balance_analysis_dict(
     model,

--- a/docs/src/examples/14_simplified_enzyme_constrained.jl
+++ b/docs/src/examples/14_simplified_enzyme_constrained.jl
@@ -36,7 +36,7 @@ rxns = filter(
     x ->
         !looks_like_biomass_reaction(x) &&
             !looks_like_exchange_reaction(x) &&
-            !isnothing(reaction_gene_association(model, x)),
+            !isnothing(reaction_gene_associations(model, x)),
     variables(model),
 )
 
@@ -47,7 +47,7 @@ rxns = filter(
 
 rxn_isozymes = Dict(
     rxn => Isozyme(
-        Dict(vcat(reaction_gene_association(model, rxn)...) .=> 1),
+        Dict(vcat(reaction_gene_associations(model, rxn)...) .=> 1),
         randn() * 100 + 600, #forward kcat
         randn() * 100 + 500, #reverse kcat
     ) for rxn in rxns

--- a/docs/src/examples/15_enzyme_constrained.jl
+++ b/docs/src/examples/15_enzyme_constrained.jl
@@ -34,7 +34,7 @@ rxns = filter(
     x ->
         !looks_like_biomass_reaction(x) &&
             !looks_like_exchange_reaction(x) &&
-            !isnothing(reaction_gene_association(model, x)),
+            !isnothing(reaction_gene_associations(model, x)),
     variables(model),
 )
 
@@ -47,7 +47,7 @@ rxn_isozymes = Dict(
             Dict(isozyme_genes .=> 1),
             randn() * 100 + 600, #forward kcat
             randn() * 100 + 500, #reverse kcat
-        ) for isozyme_genes in reaction_gene_association(model, rxn)
+        ) for isozyme_genes in reaction_gene_associations(model, rxn)
     ] for rxn in rxns
 )
 

--- a/src/analysis/modifications/knockout.jl
+++ b/src/analysis/modifications/knockout.jl
@@ -35,7 +35,7 @@ other models.
 """
 function _do_knockout(model::AbstractMetabolicModel, opt_model, gene_ids::Vector{String})
     for (rxn_num, rxn_id) in enumerate(variables(model))
-        rga = reaction_gene_association(model, rxn_id)
+        rga = reaction_gene_associations(model, rxn_id)
         if !isnothing(rga) &&
            all([any(in.(gene_ids, Ref(conjunction))) for conjunction in rga])
             set_optmodel_bound!(rxn_num, opt_model, lower = 0, upper = 0)

--- a/src/reconstruction/ObjectModel.jl
+++ b/src/reconstruction/ObjectModel.jl
@@ -76,7 +76,7 @@ function remove_genes!(
         for (rid, r) in model.reactions
             if !isnothing(r.gene_associations) && all(
                 any(in.(gids, Ref(conjunction))) for
-                conjunction in reaction_gene_association(model, rid)
+                conjunction in reaction_gene_associations(model, rid)
             )
                 push!(rm_reactions, rid)
             end

--- a/src/types/accessors/AbstractMetabolicModel.jl
+++ b/src/types/accessors/AbstractMetabolicModel.jl
@@ -195,7 +195,7 @@ Returns the sets of genes that need to be present so that the reaction can work
 For simplicity, `nothing` may be returned, meaning that the reaction always
 takes place. (in DNF, that would be equivalent to returning `[[]]`.)
 """
-function reaction_gene_association(
+function reaction_gene_associations(
     a::AbstractMetabolicModel,
     reaction_id::String,
 )::Maybe{GeneAssociationsDNF}

--- a/src/types/accessors/ModelWrapper.jl
+++ b/src/types/accessors/ModelWrapper.jl
@@ -16,7 +16,7 @@ end
 
 @inherit_model_methods_fn AbstractModelWrapper () unwrap_model () variables metabolites stoichiometry bounds balance objective reactions n_reactions reaction_variables coupling n_coupling_constraints coupling_bounds genes n_genes precache!
 
-@inherit_model_methods_fn AbstractModelWrapper (rid::String,) unwrap_model (rid,) reaction_gene_association reaction_subsystem reaction_stoichiometry reaction_annotations reaction_notes
+@inherit_model_methods_fn AbstractModelWrapper (rid::String,) unwrap_model (rid,) reaction_gene_associations reaction_subsystem reaction_stoichiometry reaction_annotations reaction_notes
 
 @inherit_model_methods_fn AbstractModelWrapper (mid::String,) unwrap_model (mid,) metabolite_formula metabolite_charge metabolite_compartment metabolite_annotations metabolite_notes
 

--- a/src/types/models/BalancedGrowthCommunityModel.jl
+++ b/src/types/models/BalancedGrowthCommunityModel.jl
@@ -264,7 +264,7 @@ will not have things like annotations etc. For this reason, these methods will
 only work if they access something inside the community members.
 =#
 for (func, def) in (
-    (:reaction_gene_association, nothing),
+    (:reaction_gene_associations, nothing),
     (:reaction_subsystem, nothing),
     (:reaction_stoichiometry, nothing),
     (:metabolite_formula, nothing),

--- a/src/types/models/JSONModel.jl
+++ b/src/types/models/JSONModel.jl
@@ -165,7 +165,7 @@ $(TYPEDSIGNATURES)
 
 Parses the `.gene_reaction_rule` from reactions.
 """
-Accessors.reaction_gene_association(model::JSONModel, rid::String) = maybemap(
+Accessors.reaction_gene_associations(model::JSONModel, rid::String) = maybemap(
     parse_grr,
     get(model.rxns[model.rxn_index[rid]], "gene_reaction_rule", nothing),
 )
@@ -338,7 +338,7 @@ function Base.convert(::Type{JSONModel}, mm::AbstractMetabolicModel)
             res["annotation"] = reaction_annotations(mm, rid)
             res["notes"] = reaction_notes(mm, rid)
 
-            grr = reaction_gene_association(mm, rid)
+            grr = reaction_gene_associations(mm, rid)
             if !isnothing(grr)
                 res["gene_reaction_rule"] = unparse_grr(String, grr)
             end

--- a/src/types/models/MATModel.jl
+++ b/src/types/models/MATModel.jl
@@ -252,7 +252,7 @@ function Base.convert(::Type{MATModel}, m::AbstractMetabolicModel)
                     "",
                     maybemap.(
                         x -> unparse_grr(String, x),
-                        reaction_gene_association.(Ref(m), variables(m)),
+                        reaction_gene_associations.(Ref(m), variables(m)),
                     ),
                 ),
             "metFormulas" =>

--- a/src/types/models/MATModel.jl
+++ b/src/types/models/MATModel.jl
@@ -131,7 +131,7 @@ $(TYPEDSIGNATURES)
 
 Extracts the associations from `grRules` key, if present.
 """
-function Accessors.reaction_gene_association(m::MATModel, rid::String)
+function Accessors.reaction_gene_associations(m::MATModel, rid::String)
     if haskey(m.mat, "grRules")
         grr = m.mat["grRules"][findfirst(==(rid), variables(m))]
         typeof(grr) == String ? parse_grr(grr) : nothing

--- a/src/types/models/MatrixModel.jl
+++ b/src/types/models/MatrixModel.jl
@@ -131,7 +131,7 @@ $(TYPEDSIGNATURES)
 Retrieve the gene reaction associations from [`MatrixModel`](@ref) by reaction
 index.
 """
-Accessors.reaction_gene_association(
+Accessors.reaction_gene_associations(
     model::MatrixModel,
     ridx::Int,
 )::Maybe{GeneAssociationsDNF} = model.grrs[ridx]
@@ -141,7 +141,7 @@ $(TYPEDSIGNATURES)
 
 Retrieve the [`GeneAssociation`](@ref) from [`MatrixModel`](@ref) by reaction ID.
 """
-Accessors.reaction_gene_association(
+Accessors.reaction_gene_associations(
     model::MatrixModel,
     rid::String,
 )::Maybe{GeneAssociationsDNF} = model.grrs[first(indexin([rid], model.rxns))]
@@ -166,7 +166,7 @@ function Base.convert(::Type{MatrixModel}, m::M) where {M<:AbstractMetabolicMode
         variables(m),
         metabolites(m),
         Vector{Maybe{GeneAssociationsDNF}}([
-            reaction_gene_association(m, id) for id in variables(m)
+            reaction_gene_associations(m, id) for id in variables(m)
         ]),
     )
 end

--- a/src/types/models/ObjectModel.jl
+++ b/src/types/models/ObjectModel.jl
@@ -168,7 +168,7 @@ $(TYPEDSIGNATURES)
 Return the gene reaction rule in string format for reaction with `id` in `model`.
 Return `nothing` if not available.
 """
-function Accessors.reaction_gene_association(
+function Accessors.reaction_gene_associations(
     model::ObjectModel,
     id::String,
 )::Maybe{GeneAssociationsDNF}
@@ -345,7 +345,7 @@ function Base.convert(::Type{ObjectModel}, model::AbstractMetabolicModel)
         for (j, stoich) in zip(findnz(S[:, i])...)
             rmets[metids[j]] = stoich
         end
-        rgas = reaction_gene_association(model, rid)
+        rgas = reaction_gene_associations(model, rid)
         modelreactions[rid] = Reaction(
             rid;
             name = reaction_name(model, rid),

--- a/src/types/models/SBMLModel.jl
+++ b/src/types/models/SBMLModel.jl
@@ -109,7 +109,7 @@ $(TYPEDSIGNATURES)
 
 Retrieve the reaction gene associations from [`SBMLModel`](@ref).
 """
-Accessors.reaction_gene_association(
+Accessors.reaction_gene_associations(
     model::SBMLModel,
     rid::String,
 )::Maybe{GeneAssociationsDNF} =
@@ -344,7 +344,7 @@ function Base.convert(::Type{SBMLModel}, mm::AbstractMetabolicModel)
                     upper_bound = "UPPER_BOUND",
                     gene_product_association = maybemap(
                         x -> unparse_grr(SBML.GeneProductAssociation, x),
-                        reaction_gene_association(mm, rid),
+                        reaction_gene_associations(mm, rid),
                     ),
                     reversible = true,
                     sbo = _sbml_export_sbo(reaction_annotations(mm, rid)),

--- a/test/reconstruction/enzyme_constrained.jl
+++ b/test/reconstruction/enzyme_constrained.jl
@@ -9,7 +9,7 @@
                     stoichiometry = Dict(grr .=> ecoli_core_protein_stoichiometry[rid][i]),
                     kcat_forward = ecoli_core_reaction_kcats[rid][i][1],
                     kcat_backward = ecoli_core_reaction_kcats[rid][i][2],
-                ) for (i, grr) in enumerate(reaction_gene_association(model, rid))
+                ) for (i, grr) in enumerate(reaction_gene_associations(model, rid))
             ) : nothing
 
     get_gene_product_mass = gid -> get(ecoli_core_gene_product_masses, gid, 0.0)
@@ -126,7 +126,7 @@ end
         m;
         reaction_isozymes = Dict(
             rid => r.gene_associations for (rid, r) in m.reactions if
-            !isnothing(reaction_gene_association(m, rid)) && rid in ["r3", "r4", "r5"]
+            !isnothing(reaction_gene_associations(m, rid)) && rid in ["r3", "r4", "r5"]
         ),
         gene_product_bounds,
         gene_product_molar_mass,

--- a/test/reconstruction/simplified_enzyme_constrained.jl
+++ b/test/reconstruction/simplified_enzyme_constrained.jl
@@ -12,7 +12,7 @@
                     stoichiometry = Dict(grr .=> ecoli_core_protein_stoichiometry[rid][i]),
                     kcat_forward = ecoli_core_reaction_kcats[rid][i][1],
                     kcat_backward = ecoli_core_reaction_kcats[rid][i][2],
-                ) for (i, grr) in enumerate(reaction_gene_association(model, rid))
+                ) for (i, grr) in enumerate(reaction_gene_associations(model, rid))
             ) : nothing
 
     simplified_enzyme_constrained_model =

--- a/test/types/BalancedGrowthCommunityModel.jl
+++ b/test/types/BalancedGrowthCommunityModel.jl
@@ -280,7 +280,7 @@ end
                     stoichiometry = Dict(grr .=> ecoli_core_protein_stoichiometry[rid][i]),
                     kcat_forward = ecoli_core_reaction_kcats[rid][i][1],
                     kcat_backward = ecoli_core_reaction_kcats[rid][i][2],
-                ) for (i, grr) in enumerate(reaction_gene_association(ecoli, rid))
+                ) for (i, grr) in enumerate(reaction_gene_associations(ecoli, rid))
             ) : nothing
 
     get_gene_product_mass = gid -> get(ecoli_core_gene_product_masses, gid, 0.0)

--- a/test/types/MatrixCoupling.jl
+++ b/test/types/MatrixCoupling.jl
@@ -15,6 +15,6 @@ end
     @test Set(variables(cm)) == Set(variables(sm))
     @test Set(variables(cm)) == Set(variables(cm2))
 
-    @test reaction_gene_association(sm, variables(sm)[1]) ==
-          reaction_gene_association(cm, variables(sm)[1])
+    @test reaction_gene_associations(sm, variables(sm)[1]) ==
+          reaction_gene_associations(cm, variables(sm)[1])
 end

--- a/test/types/MatrixModel.jl
+++ b/test/types/MatrixModel.jl
@@ -14,6 +14,6 @@ end
     @test Set(variables(cm)) == Set(variables(sm))
     @test Set(variables(cm)) == Set(variables(cm2))
 
-    @test reaction_gene_association(sm, variables(sm)[1]) ==
-          reaction_gene_association(cm, variables(sm)[1])
+    @test reaction_gene_associations(sm, variables(sm)[1]) ==
+          reaction_gene_associations(cm, variables(sm)[1])
 end

--- a/test/types/ObjectModel.jl
+++ b/test/types/ObjectModel.jl
@@ -90,12 +90,12 @@
             Ref(
                 COBREXA.Internal.unparse_grr(
                     String,
-                    reaction_gene_association(model, "r1"),
+                    reaction_gene_associations(model, "r1"),
                 ),
             ),
         ),
     )
-    @test isnothing(reaction_gene_association(model, "r2"))
+    @test isnothing(reaction_gene_associations(model, "r2"))
 
     @test metabolite_formula(model, "m2")["C"] == 2
     @test isnothing(metabolite_formula(model, "m3"))


### PR DESCRIPTION
This is more consistent since we use `xxx_notes` and `xxx_annotations` and the rgas are vectors