### PR TITLE
GPA ordering fix

### DIFF
--- a/test/analysis/gecko.jl
+++ b/test/analysis/gecko.jl
@@ -41,7 +41,7 @@
 
     @test isapprox(
         rxn_fluxes["BIOMASS_Ecoli_core_w_GAM"],
-        0.8128427019072836,
+        0.8128851171859416,
         atol = TEST_TOLERANCE,
     )
 

--- a/test/analysis/smoment.jl
+++ b/test/analysis/smoment.jl
@@ -35,7 +35,7 @@
 
     @test isapprox(
         rxn_fluxes["BIOMASS_Ecoli_core_w_GAM"],
-        0.8907347602586123,
+        0.8907680040632139,
         atol = TEST_TOLERANCE,
     )
 end

--- a/test/io/io.jl
+++ b/test/io/io.jl
@@ -22,5 +22,5 @@
     @test n_reactions(reconmodel) == 10600
     recon_grrs = [r.grr for (i, r) in reconmodel.reactions if !isnothing(r.grr)]
     @test length(recon_grrs) == 5938
-    @test sum(length.(recon_grrs)) == 31504
+    @test sum(length.(recon_grrs)) == 31503
 end


### PR DESCRIPTION
(direct consequence of `unique` use in #731 )