### PR TITLE
Add more reconstruction functions to ObjectModel

### DIFF
--- a/src/reconstruction/ObjectModel.jl
+++ b/src/reconstruction/ObjectModel.jl
@@ -122,7 +122,7 @@ $(TYPEDSIGNATURES)
 
 Add `gene` to `model` and return a shallow copied version of the model.
 """
-add_gene(model::ObjectModel, gene::Gene) = add_genes(model, [gene,])
+add_gene(model::ObjectModel, gene::Gene) = add_genes(model, [gene])
 
 """
 $(TYPEDSIGNATURES)

--- a/src/reconstruction/ObjectModel.jl
+++ b/src/reconstruction/ObjectModel.jl
@@ -15,7 +15,7 @@ $(TYPEDSIGNATURES)
 
 Add `rxn` to `model` based on reaction `id`.
 """
-add_reaction!(model::ObjectModel, rxn::Reaction) = add_reactions!(model, [rxn,])
+add_reaction!(model::ObjectModel, rxn::Reaction) = add_reactions!(model, [rxn])
 
 """
 $(TYPEDSIGNATURES)
@@ -38,7 +38,7 @@ $(TYPEDSIGNATURES)
 
 Add `rxn` to `model`, and return a shallow copied version of the model.
 """
-add_reaction(model::ObjectModel, rxn::Reaction) = add_reactions(model, [rxn,]) 
+add_reaction(model::ObjectModel, rxn::Reaction) = add_reactions(model, [rxn])
 
 """
 $(TYPEDSIGNATURES)
@@ -57,7 +57,7 @@ $(TYPEDSIGNATURES)
 
 Add `met` to `model` based on metabolite `id`.
 """
-add_metabolite!(model::ObjectModel, met::Metabolite) = add_metabolites!(model, [met,])
+add_metabolite!(model::ObjectModel, met::Metabolite) = add_metabolites!(model, [met])
 
 """
 $(TYPEDSIGNATURES)
@@ -80,7 +80,7 @@ $(TYPEDSIGNATURES)
 
 Add `met` to `model` and return a shallow copied version of the model.
 """
-add_metabolite(model::ObjectModel, met::Metabolite) = add_metabolites(model, [met,])
+add_metabolite(model::ObjectModel, met::Metabolite) = add_metabolites(model, [met])
 
 """
 $(TYPEDSIGNATURES)
@@ -122,7 +122,7 @@ $(TYPEDSIGNATURES)
 
 Add `gene` to `model` and return a shallow copied version of the model.
 """
-add_gene(model::ObjectModel, gene::Gene) = add_genes(model, [gene,])
+add_gene(model::ObjectModel, gene::Gene) = add_genes(model, [gene])
 
 """
 $(TYPEDSIGNATURES)

--- a/src/reconstruction/ObjectModel.jl
+++ b/src/reconstruction/ObjectModel.jl
@@ -15,7 +15,30 @@ $(TYPEDSIGNATURES)
 
 Add `rxn` to `model` based on reaction `id`.
 """
-add_reaction!(model::ObjectModel, rxn::Reaction) = add_reactions!(model, [rxn])
+add_reaction!(model::ObjectModel, rxn::Reaction) = add_reactions!(model, [rxn,])
+
+"""
+$(TYPEDSIGNATURES)
+
+Add `rxns` to `model` and return a shallow copied version of the model.
+"""
+function add_reactions(model::ObjectModel, rxns::Vector{Reaction})
+    m = copy(model)
+
+    m.reactions = copy(m.reactions)
+    for rxn in rxns
+        m.reactions[rxn.id] = rxn
+    end
+
+    return m
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Add `rxn` to `model`, and return a shallow copied version of the model.
+"""
+add_reaction(model::ObjectModel, rxn::Reaction) = add_reactions(model, [rxn,]) 
 
 """
 $(TYPEDSIGNATURES)
@@ -34,7 +57,30 @@ $(TYPEDSIGNATURES)
 
 Add `met` to `model` based on metabolite `id`.
 """
-add_metabolite!(model::ObjectModel, met::Metabolite) = add_metabolites!(model, [met])
+add_metabolite!(model::ObjectModel, met::Metabolite) = add_metabolites!(model, [met,])
+
+"""
+$(TYPEDSIGNATURES)
+
+Add `mets` to `model` and return a shallow copied version of the model.
+"""
+function add_metabolites(model::ObjectModel, mets::Vector{Metabolite})
+    m = copy(model)
+
+    m.metabolites = copy(m.metabolites)
+    for met in mets
+        m.metabolites[met.id] = met
+    end
+
+    return m
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Add `met` to `model` and return a shallow copied version of the model.
+"""
+add_metabolite(model::ObjectModel, met::Metabolite) = add_metabolites(model, [met,])
 
 """
 $(TYPEDSIGNATURES)
@@ -53,7 +99,30 @@ $(TYPEDSIGNATURES)
 
 Add `gene` to `model` based on gene `id`.
 """
-add_gene!(model::ObjectModel, gene::Gene) = add_genes!(model, [gene])
+add_genes!(model::ObjectModel, gene::Gene) = add_genes!(model, [gene])
+
+"""
+$(TYPEDSIGNATURES)
+
+Add `gns` to `model` and return a shallow copied version of the model.
+"""
+function add_genes(model::ObjectModel, genes::Vector{Gene})
+    m = copy(model)
+
+    m.genes = copy(m.genes)
+    for gn in genes
+        m.genes[gn.id] = gn
+    end
+
+    return m
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Add `gene` to `model` and return a shallow copied version of the model.
+"""
+add_gene(model::ObjectModel, gene::Gene) = add_genes(model, [gene,])
 
 """
 $(TYPEDSIGNATURES)

--- a/src/reconstruction/ObjectModel.jl
+++ b/src/reconstruction/ObjectModel.jl
@@ -99,7 +99,7 @@ $(TYPEDSIGNATURES)
 
 Add `gene` to `model` based on gene `id`.
 """
-add_genes!(model::ObjectModel, gene::Gene) = add_genes!(model, [gene])
+add_gene!(model::ObjectModel, gene::Gene) = add_genes!(model, [gene])
 
 """
 $(TYPEDSIGNATURES)
@@ -122,7 +122,7 @@ $(TYPEDSIGNATURES)
 
 Add `gene` to `model` and return a shallow copied version of the model.
 """
-add_gene(model::ObjectModel, gene::Gene) = add_genes(model, [gene])
+add_gene(model::ObjectModel, gene::Gene) = add_genes(model, [gene,])
 
 """
 $(TYPEDSIGNATURES)

--- a/src/reconstruction/pipes/generic.jl
+++ b/src/reconstruction/pipes/generic.jl
@@ -1,6 +1,54 @@
 """
 $(TYPEDSIGNATURES)
 
+Specifies a model variant with reactions added. Forwards the arguments to
+[`add_reactions`](@ref). 
+"""
+with_added_reactions(args...; kwargs...) = m -> add_reactions(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant with an added reaction. Forwards the arguments to
+[`add_reaction`](@ref).
+"""
+with_added_reaction(args...; kwargs...) = m -> add_reaction(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant with metabolites added. Forwards the arguments to
+[`add_metabolites`](@ref). 
+"""
+with_added_metabolites(args...; kwargs...) = m -> add_metabolites(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant with an added metabolite. Forwards the arguments to
+[`add_metabolite`](@ref).
+"""
+with_added_metabolite(args...; kwargs...) = m -> add_metabolite(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant with genes added. Forwards the arguments to
+[`add_genes`](@ref). 
+"""
+with_added_genes(args...; kwargs...) = m -> add_genes(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant with an added gene. Forwards the arguments to
+[`add_gene`](@ref).
+"""
+with_added_gene(args...; kwargs...) = m -> add_gene(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
 Specifies a model variant that has a new bound set. Forwards arguments to
 [`change_bound`](@ref). Intended for usage with [`screen`](@ref).
 """
@@ -18,7 +66,7 @@ with_changed_bounds(args...; kwargs...) = m -> change_bounds(m, args...; kwargs.
 $(TYPEDSIGNATURES)
 
 Specifies a model variant without a certain metabolite. Forwards arguments to
-[`remove_metabolite`](@ref). Intended to be used with [`screen`](@ref).
+[`remove_metabolite`](@ref). 
 """
 with_removed_metabolite(args...; kwargs...) = m -> remove_metabolite(m, args...; kwargs...)
 
@@ -34,16 +82,8 @@ with_removed_metabolites(args...; kwargs...) =
 """
 $(TYPEDSIGNATURES)
 
-Specifies a model variant with reactions added. Forwards the arguments to
-[`add_reactions`](@ref). Intended to be used with [`screen`](@ref).
-"""
-with_added_reactions(args...; kwargs...) = m -> add_reactions(m, args...; kwargs...)
-
-"""
-$(TYPEDSIGNATURES)
-
 Specifies a model variant without a certain reaction. Forwards arguments to
-[`remove_reaction`](@ref). Intended to be used with [`screen`](@ref).
+[`remove_reaction`](@ref). 
 """
 with_removed_reaction(args...; kwargs...) = m -> remove_reaction(m, args...; kwargs...)
 
@@ -55,7 +95,6 @@ Plural version of [`with_removed_reaction`](@ref), calls
 """
 with_removed_reactions(args...; kwargs...) = m -> remove_reactions(m, args...; kwargs...)
 
-
 """
 $(TYPEDSIGNATURES)
 
@@ -64,3 +103,5 @@ Forwards arguments to [`add_biomass_metabolite`](@ref).
 """
 with_added_biomass_metabolite(args...; kwargs...) =
     m -> add_biomass_metabolite(m, args...; kwargs...)
+
+

--- a/src/reconstruction/pipes/generic.jl
+++ b/src/reconstruction/pipes/generic.jl
@@ -2,7 +2,7 @@
 $(TYPEDSIGNATURES)
 
 Specifies a model variant with reactions added. Forwards the arguments to
-[`add_reactions`](@ref). 
+[`add_reactions`](@ref).
 """
 with_added_reactions(args...; kwargs...) = m -> add_reactions(m, args...; kwargs...)
 
@@ -18,7 +18,7 @@ with_added_reaction(args...; kwargs...) = m -> add_reaction(m, args...; kwargs..
 $(TYPEDSIGNATURES)
 
 Specifies a model variant with metabolites added. Forwards the arguments to
-[`add_metabolites`](@ref). 
+[`add_metabolites`](@ref).
 """
 with_added_metabolites(args...; kwargs...) = m -> add_metabolites(m, args...; kwargs...)
 
@@ -34,7 +34,7 @@ with_added_metabolite(args...; kwargs...) = m -> add_metabolite(m, args...; kwar
 $(TYPEDSIGNATURES)
 
 Specifies a model variant with genes added. Forwards the arguments to
-[`add_genes`](@ref). 
+[`add_genes`](@ref).
 """
 with_added_genes(args...; kwargs...) = m -> add_genes(m, args...; kwargs...)
 
@@ -66,7 +66,7 @@ with_changed_bounds(args...; kwargs...) = m -> change_bounds(m, args...; kwargs.
 $(TYPEDSIGNATURES)
 
 Specifies a model variant without a certain metabolite. Forwards arguments to
-[`remove_metabolite`](@ref). 
+[`remove_metabolite`](@ref).
 """
 with_removed_metabolite(args...; kwargs...) = m -> remove_metabolite(m, args...; kwargs...)
 
@@ -83,7 +83,7 @@ with_removed_metabolites(args...; kwargs...) =
 $(TYPEDSIGNATURES)
 
 Specifies a model variant without a certain reaction. Forwards arguments to
-[`remove_reaction`](@ref). 
+[`remove_reaction`](@ref).
 """
 with_removed_reaction(args...; kwargs...) = m -> remove_reaction(m, args...; kwargs...)
 
@@ -103,5 +103,3 @@ Forwards arguments to [`add_biomass_metabolite`](@ref).
 """
 with_added_biomass_metabolite(args...; kwargs...) =
     m -> add_biomass_metabolite(m, args...; kwargs...)
-
-


### PR DESCRIPTION
Adds non-inplace reconstruction functions and pipes for ObjectModel. Looking at the code, it screams "use a macro", but let's do this after 2.0 is out