### PR TITLE
Add another convenience constructor for enzyme constrained models

### DIFF
--- a/src/reconstruction/enzyme_constrained.jl
+++ b/src/reconstruction/enzyme_constrained.jl
@@ -165,3 +165,19 @@ function make_enzyme_constrained_model(
         model,
     )
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+A convenience wrapper around [`make_enzyme_constrained_model`](@ref) that
+enforces a global enzyme capacity limitation across all genes in the model with
+`total_capacity_limitation` being the bound.
+"""
+make_enzyme_constrained_model(
+    model::AbstractMetabolicModel,
+    total_capacity_limitation::Float64,
+) = make_enzyme_constrained_model(
+    model;
+    gene_product_mass_group = Dict("uncategorized" => genes(model)),
+    gene_product_mass_group_bound = Dict("uncategorized" => total_capacity_limitation),
+)

--- a/src/reconstruction/pipes/enzymes.jl
+++ b/src/reconstruction/pipes/enzymes.jl
@@ -15,8 +15,8 @@ Specifies a model variant which adds extra semantics of the EnzymeConstrained al
 giving a [`EnzymeConstrainedModel`](@ref). The arguments are forwarded to
 [`make_enzyme_constrained_model`](@ref). Intended for usage with [`screen`](@ref).
 """
-with_enzyme_constraints(; kwargs...) =
-    model -> make_enzyme_constrained_model(model; kwargs...)
+with_enzyme_constraints(args...; kwargs...) =
+    model -> make_enzyme_constrained_model(model, args...; kwargs...)
 
 """
 $(TYPEDSIGNATURES)

--- a/test/reconstruction/enzyme_constrained.jl
+++ b/test/reconstruction/enzyme_constrained.jl
@@ -45,11 +45,7 @@
             lower_bound = [-1000.0, -1.0],
             upper_bound = [nothing, 12.0],
         ) |>
-        with_enzyme_constraints(
-            gene_product_mass_group_bound = Dict(
-                "uncategorized" => total_gene_product_mass,
-            ),
-        )
+        with_enzyme_constraints(total_gene_product_mass)
 
     opt_model = flux_balance_analysis(
         gm,


### PR DESCRIPTION
Adds a simpler fallback for `make_enzyme_constrained_model` and generalizes the pipe. Also added the test. 