### PR TITLE
Remove unnecessary docstrings

### DIFF
--- a/src/types/accessors/AbstractMetabolicModel.jl
+++ b/src/types/accessors/AbstractMetabolicModel.jl
@@ -12,14 +12,15 @@
 """
 $(TYPEDSIGNATURES)
 
-Return a vector of reaction identifiers in a model. The vector precisely
+Return a vector of variable identifiers in a model. The vector precisely
 corresponds to the columns in [`stoichiometry`](@ref) matrix.
 
-For technical reasons, the "reactions" may sometimes not be true reactions but
-various virtual and helper pseudo-reactions that are used in the metabolic
-modeling, such as metabolite exchanges, separate forward and reverse reactions,
-supplies of enzymatic and genetic material and virtual cell volume, etc. To
-simplify the view of the model contents use [`reaction_variables`](@ref).
+Usually, variables correspond to reactions. However, for technical reasons, the
+reactions may sometimes not be true reactions, but various virtual and helper
+pseudo-reactions that are used in the metabolic modeling, such as metabolite
+exchanges, separate forward and reverse reactions, supplies of enzymatic and
+genetic material and virtual cell volume, etc. To simplify the view of the model
+contents use [`reaction_variables`](@ref).
 """
 function variables(a::AbstractMetabolicModel)::Vector{String}
     missing_impl_error(variables, (a,))
@@ -59,13 +60,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Get the sparse stoichiometry matrix of a model. A feasible solution `x` of a
-model `m` is defined as satisfying the equations:
-
-- `stoichiometry(m) * x .== balance(m)`
-- `x .>= lbs`
-- `y .<= ubs`
-- `(lbs, ubs) == bounds(m)
+Get the sparse stoichiometry matrix of a model.
 """
 function stoichiometry(a::AbstractMetabolicModel)::SparseMat
     missing_impl_error(stoichiometry, (a,))

--- a/src/types/models/BalancedGrowthCommunityModel.jl
+++ b/src/types/models/BalancedGrowthCommunityModel.jl
@@ -71,9 +71,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Return the number of reactions in `cm`, which is a
-[`BalancedGrowthCommunityModel`](@ref).
 """
 function Accessors.n_variables(cm::BalancedGrowthCommunityModel)
     num_model_reactions = sum(n_variables(m.model) for m in cm.members)
@@ -98,9 +95,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Return the number of metabolites in `cm`, which is a
-[`BalancedGrowthCommunityModel`](@ref).
 """
 function Accessors.n_metabolites(cm::BalancedGrowthCommunityModel)
     num_model_reactions = sum(n_metabolites(m.model) for m in cm.members)
@@ -121,7 +115,6 @@ Accessors.genes(cm::BalancedGrowthCommunityModel) =
 
 """
 $(TYPEDSIGNATURES)
-Return the balance of `cm`, which is a [`BalancedGrowthCommunityModel`](@ref).
 """
 Accessors.balance(cm::BalancedGrowthCommunityModel) = [
     vcat([balance(m.model) .* m.abundance for m in cm.members]...)
@@ -130,8 +123,6 @@ Accessors.balance(cm::BalancedGrowthCommunityModel) = [
 
 """
 $(TYPEDSIGNATURES)
-
-Return the number of metabolites in `cm`, which is a [`BalancedGrowthCommunityModel`](@ref).
 """
 Accessors.n_genes(cm::BalancedGrowthCommunityModel) =
     sum(n_genes(m.model) for m in cm.members)
@@ -139,8 +130,8 @@ Accessors.n_genes(cm::BalancedGrowthCommunityModel) =
 """
 $(TYPEDSIGNATURES)
 
-Return the overall stoichiometric matrix for a [`BalancedGrowthCommunityModel`](@ref), built
-from the underlying models.
+Return the overall stoichiometric matrix for a
+[`BalancedGrowthCommunityModel`](@ref), built from the underlying models.
 """
 function Accessors.stoichiometry(cm::BalancedGrowthCommunityModel)
     env_mets = get_env_mets(cm)
@@ -204,8 +195,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Coupling constraint matrix for a [`BalancedGrowthCommunityModel`](@ref).
 """
 function Accessors.coupling(cm::BalancedGrowthCommunityModel)
     coups = blockdiag([coupling(m.model) for m in cm.members]...)
@@ -215,8 +204,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-The number of coupling constraints in a [`BalancedGrowthCommunityModel`](@ref).
 """
 Accessors.n_coupling_constraints(cm::BalancedGrowthCommunityModel) =
     sum(n_coupling_constraints(m.model) for m in cm.members)
@@ -250,8 +237,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Returns the semantically meaningful reactions of the model.
 """
 Accessors.reactions(cm::BalancedGrowthCommunityModel) = [
     vcat([add_community_prefix.(Ref(m), reactions(m.model)) for m in cm.members]...)
@@ -261,8 +246,6 @@ Accessors.reactions(cm::BalancedGrowthCommunityModel) = [
 
 """
 $(TYPEDSIGNATURES)
-
-Return the semantically meaningful reactions of the model.
 """
 Accessors.n_reactions(cm::BalancedGrowthCommunityModel) =
     sum(n_reactions(m.model) for m in cm.members) + length(get_env_mets(cm)) + 1

--- a/src/types/models/HDF5Model.jl
+++ b/src/types/models/HDF5Model.jl
@@ -33,17 +33,11 @@ function Accessors.precache!(model::HDF5Model)::Nothing
     nothing
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.n_variables(model::HDF5Model)::Int
     precache!(model)
     length(model.h5["reactions"])
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.variables(model::HDF5Model)::Vector{String}
     precache!(model)
     # TODO is there any reasonable method to mmap strings from HDF5?
@@ -52,49 +46,31 @@ end
 
 Accessors.Internal.@all_variables_are_reactions HDF5Model
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.n_metabolites(model::HDF5Model)::Int
     precache!(model)
     length(model.h5["metabolites"])
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.metabolites(model::HDF5Model)::Vector{String}
     precache!(model)
     read(model.h5["metabolites"])
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.stoichiometry(model::HDF5Model)::SparseMat
     precache!(model)
     h5_read_sparse(SparseMat, model.h5["stoichiometry"])
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.bounds(model::HDF5Model)::Tuple{Vector{Float64},Vector{Float64}}
     precache!(model)
     (HDF5.readmmap(model.h5["lower_bounds"]), HDF5.readmmap(model.h5["upper_bounds"]))
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.balance(model::HDF5Model)::SparseVec
     precache!(model)
     h5_read_sparse(SparseVec, model.h5["balance"])
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.objective(model::HDF5Model)::SparseVec
     precache!(model)
     h5_read_sparse(SparseVec, model.h5["objective"])

--- a/src/types/models/HDF5Model.jl
+++ b/src/types/models/HDF5Model.jl
@@ -33,11 +33,17 @@ function Accessors.precache!(model::HDF5Model)::Nothing
     nothing
 end
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function Accessors.n_variables(model::HDF5Model)::Int
     precache!(model)
     length(model.h5["reactions"])
 end
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function Accessors.variables(model::HDF5Model)::Vector{String}
     precache!(model)
     # TODO is there any reasonable method to mmap strings from HDF5?
@@ -46,31 +52,49 @@ end
 
 Accessors.Internal.@all_variables_are_reactions HDF5Model
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function Accessors.n_metabolites(model::HDF5Model)::Int
     precache!(model)
     length(model.h5["metabolites"])
 end
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function Accessors.metabolites(model::HDF5Model)::Vector{String}
     precache!(model)
     read(model.h5["metabolites"])
 end
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function Accessors.stoichiometry(model::HDF5Model)::SparseMat
     precache!(model)
     h5_read_sparse(SparseMat, model.h5["stoichiometry"])
 end
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function Accessors.bounds(model::HDF5Model)::Tuple{Vector{Float64},Vector{Float64}}
     precache!(model)
     (HDF5.readmmap(model.h5["lower_bounds"]), HDF5.readmmap(model.h5["upper_bounds"]))
 end
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function Accessors.balance(model::HDF5Model)::SparseVec
     precache!(model)
     h5_read_sparse(SparseVec, model.h5["balance"])
 end
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function Accessors.objective(model::HDF5Model)::SparseVec
     precache!(model)
     h5_read_sparse(SparseVec, model.h5["objective"])

--- a/src/types/models/JSONModel.jl
+++ b/src/types/models/JSONModel.jl
@@ -71,41 +71,46 @@ end
 
 _parse_notes(x)::Notes = _parse_annotations(x)
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.n_variables(model::JSONModel) = length(model.rxns)
+
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.n_metabolites(model::JSONModel) = length(model.mets)
+
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.n_genes(model::JSONModel) = length(model.genes)
 
 """
 $(TYPEDSIGNATURES)
-
-Extract reaction names (stored as `.id`) from JSON model.
 """
 Accessors.variables(model::JSONModel) =
     [_json_rxn_name(r, i) for (i, r) in enumerate(model.rxns)]
 
 """
 $(TYPEDSIGNATURES)
-
-Extract metabolite names (stored as `.id`) from JSON model.
 """
 Accessors.metabolites(model::JSONModel) =
     [_json_met_name(m, i) for (i, m) in enumerate(model.mets)]
 
 """
 $(TYPEDSIGNATURES)
-
-Extract gene names from a JSON model.
 """
 Accessors.genes(model::JSONModel) =
     [_json_gene_name(g, i) for (i, g) in enumerate(model.genes)]
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.Internal.@all_variables_are_reactions JSONModel
 
 """
 $(TYPEDSIGNATURES)
-
-Get the stoichiometry. Assuming the information is stored in reaction object
-under key `.metabolites`.
 """
 function Accessors.stoichiometry(model::JSONModel)
     rxn_ids = variables(model)
@@ -145,9 +150,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Get the bounds for reactions, assuming the information is stored in
-`.lower_bound` and `.upper_bound`.
 """
 Accessors.bounds(model::JSONModel) = (
     [get(rxn, "lower_bound", -constants.default_reaction_bound) for rxn in model.rxns],
@@ -156,16 +158,12 @@ Accessors.bounds(model::JSONModel) = (
 
 """
 $(TYPEDSIGNATURES)
-
-Collect `.objective_coefficient` keys from model reactions.
 """
 Accessors.objective(model::JSONModel) =
     sparse([float(get(rxn, "objective_coefficient", 0.0)) for rxn in model.rxns])
 
 """
 $(TYPEDSIGNATURES)
-
-Parses the `.gene_reaction_rule` from reactions.
 """
 Accessors.reaction_gene_associations(model::JSONModel, rid::String) = maybemap(
     parse_grr,
@@ -174,8 +172,6 @@ Accessors.reaction_gene_associations(model::JSONModel, rid::String) = maybemap(
 
 """
 $(TYPEDSIGNATURES)
-
-Parse and directly evaluate the `.gene_reaction_rule` in the reaction.
 """
 Accessors.eval_reaction_gene_association(model::JSONModel, rid::String; kwargs...) =
     maybemap(
@@ -186,42 +182,29 @@ Accessors.eval_reaction_gene_association(model::JSONModel, rid::String; kwargs..
         ),
     )
 
-"""
-$(TYPEDSIGNATURES)
-
-Parses the `.subsystem` out from reactions.
-"""
 Accessors.reaction_subsystem(model::JSONModel, rid::String) =
     get(model.rxns[model.rxn_index[rid]], "subsystem", nothing)
 
 """
 $(TYPEDSIGNATURES)
-
-Parse and return the metabolite `.formula`
 """
 Accessors.metabolite_formula(model::JSONModel, mid::String) =
     maybemap(parse_formula, get(model.mets[model.met_index[mid]], "formula", nothing))
 
 """
 $(TYPEDSIGNATURES)
-
-Return the metabolite `.charge`
 """
 Accessors.metabolite_charge(model::JSONModel, mid::String) =
     get(model.mets[model.met_index[mid]], "charge", 0)
 
 """
 $(TYPEDSIGNATURES)
-
-Return the metabolite `.compartment`
 """
 Accessors.metabolite_compartment(model::JSONModel, mid::String) =
     get(model.mets[model.met_index[mid]], "compartment", nothing)
 
 """
 $(TYPEDSIGNATURES)
-
-Gene annotations from the [`JSONModel`](@ref).
 """
 Accessors.gene_annotations(model::JSONModel, gid::String)::Annotations = maybemap(
     _parse_annotations,
@@ -230,16 +213,12 @@ Accessors.gene_annotations(model::JSONModel, gid::String)::Annotations = maybema
 
 """
 $(TYPEDSIGNATURES)
-
-Gene notes from the [`JSONModel`](@ref).
 """
 Accessors.gene_notes(model::JSONModel, gid::String)::Notes =
     maybemap(_parse_notes, get(model.genes[model.gene_index[gid]], "notes", nothing))
 
 """
 $(TYPEDSIGNATURES)
-
-Reaction annotations from the [`JSONModel`](@ref).
 """
 Accessors.reaction_annotations(model::JSONModel, rid::String)::Annotations = maybemap(
     _parse_annotations,
@@ -248,16 +227,12 @@ Accessors.reaction_annotations(model::JSONModel, rid::String)::Annotations = may
 
 """
 $(TYPEDSIGNATURES)
-
-Reaction notes from the [`JSONModel`](@ref).
 """
 Accessors.reaction_notes(model::JSONModel, rid::String)::Notes =
     maybemap(_parse_notes, get(model.rxns[model.rxn_index[rid]], "notes", nothing))
 
 """
 $(TYPEDSIGNATURES)
-
-Metabolite annotations from the [`JSONModel`](@ref).
 """
 Accessors.metabolite_annotations(model::JSONModel, mid::String)::Annotations = maybemap(
     _parse_annotations,
@@ -266,53 +241,47 @@ Accessors.metabolite_annotations(model::JSONModel, mid::String)::Annotations = m
 
 """
 $(TYPEDSIGNATURES)
-
-Metabolite notes from the [`JSONModel`](@ref).
 """
 Accessors.metabolite_notes(model::JSONModel, mid::String)::Notes =
     maybemap(_parse_notes, get(model.mets[model.met_index[mid]], "notes", nothing))
 
 """
 $(TYPEDSIGNATURES)
-
-Return the stoichiometry of reaction with ID `rid`.
 """
 Accessors.reaction_stoichiometry(model::JSONModel, rid::String)::Dict{String,Float64} =
     model.rxns[model.rxn_index[rid]]["metabolites"]
 
 """
 $(TYPEDSIGNATURES)
-
-Return the name of reaction with ID `rid`.
 """
 Accessors.reaction_name(model::JSONModel, rid::String) =
     get(model.rxns[model.rxn_index[rid]], "name", nothing)
 
 """
 $(TYPEDSIGNATURES)
-
-Return the name of metabolite with ID `mid`.
 """
 Accessors.metabolite_name(model::JSONModel, mid::String) =
     get(model.mets[model.met_index[mid]], "name", nothing)
 
 """
 $(TYPEDSIGNATURES)
-
-Return the name of gene with ID `gid`.
 """
 Accessors.gene_name(model::JSONModel, gid::String) =
     get(model.genes[model.gene_index[gid]], "name", nothing)
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.model_annotations(model::JSONModel)::Annotations =
     get(model.json, "annotation", Annotations())
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.model_notes(model::JSONModel)::Notes = get(model.json, "notes", Notes())
 
 """
 $(TYPEDSIGNATURES)
-
-Convert any [`AbstractMetabolicModel`](@ref) to [`JSONModel`](@ref).
 """
 function Base.convert(::Type{JSONModel}, mm::AbstractMetabolicModel)
     if typeof(mm) == JSONModel

--- a/src/types/models/JSONModel.jl
+++ b/src/types/models/JSONModel.jl
@@ -104,9 +104,6 @@ $(TYPEDSIGNATURES)
 Accessors.genes(model::JSONModel) =
     [_json_gene_name(g, i) for (i, g) in enumerate(model.genes)]
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.Internal.@all_variables_are_reactions JSONModel
 
 """

--- a/src/types/models/JSONModel.jl
+++ b/src/types/models/JSONModel.jl
@@ -71,44 +71,23 @@ end
 
 _parse_notes(x)::Notes = _parse_annotations(x)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_variables(model::JSONModel) = length(model.rxns)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_metabolites(model::JSONModel) = length(model.mets)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_genes(model::JSONModel) = length(model.genes)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.variables(model::JSONModel) =
     [_json_rxn_name(r, i) for (i, r) in enumerate(model.rxns)]
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolites(model::JSONModel) =
     [_json_met_name(m, i) for (i, m) in enumerate(model.mets)]
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.genes(model::JSONModel) =
     [_json_gene_name(g, i) for (i, g) in enumerate(model.genes)]
 
 Accessors.Internal.@all_variables_are_reactions JSONModel
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.stoichiometry(model::JSONModel)
     rxn_ids = variables(model)
     met_ids = metabolites(model)
@@ -145,31 +124,19 @@ function Accessors.stoichiometry(model::JSONModel)
     return SparseArrays.sparse(MI, RI, SV, length(met_ids), length(rxn_ids))
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.bounds(model::JSONModel) = (
     [get(rxn, "lower_bound", -constants.default_reaction_bound) for rxn in model.rxns],
     [get(rxn, "upper_bound", constants.default_reaction_bound) for rxn in model.rxns],
 )
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.objective(model::JSONModel) =
     sparse([float(get(rxn, "objective_coefficient", 0.0)) for rxn in model.rxns])
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_gene_associations(model::JSONModel, rid::String) = maybemap(
     parse_grr,
     get(model.rxns[model.rxn_index[rid]], "gene_reaction_rule", nothing),
 )
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.eval_reaction_gene_association(model::JSONModel, rid::String; kwargs...) =
     maybemap(
         x -> eval_grr(x; kwargs...),
@@ -182,104 +149,56 @@ Accessors.eval_reaction_gene_association(model::JSONModel, rid::String; kwargs..
 Accessors.reaction_subsystem(model::JSONModel, rid::String) =
     get(model.rxns[model.rxn_index[rid]], "subsystem", nothing)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_formula(model::JSONModel, mid::String) =
     maybemap(parse_formula, get(model.mets[model.met_index[mid]], "formula", nothing))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_charge(model::JSONModel, mid::String) =
     get(model.mets[model.met_index[mid]], "charge", 0)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_compartment(model::JSONModel, mid::String) =
     get(model.mets[model.met_index[mid]], "compartment", nothing)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.gene_annotations(model::JSONModel, gid::String)::Annotations = maybemap(
     _parse_annotations,
     get(model.genes[model.gene_index[gid]], "annotation", nothing),
 )
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.gene_notes(model::JSONModel, gid::String)::Notes =
     maybemap(_parse_notes, get(model.genes[model.gene_index[gid]], "notes", nothing))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_annotations(model::JSONModel, rid::String)::Annotations = maybemap(
     _parse_annotations,
     get(model.rxns[model.rxn_index[rid]], "annotation", nothing),
 )
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_notes(model::JSONModel, rid::String)::Notes =
     maybemap(_parse_notes, get(model.rxns[model.rxn_index[rid]], "notes", nothing))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_annotations(model::JSONModel, mid::String)::Annotations = maybemap(
     _parse_annotations,
     get(model.mets[model.met_index[mid]], "annotation", nothing),
 )
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_notes(model::JSONModel, mid::String)::Notes =
     maybemap(_parse_notes, get(model.mets[model.met_index[mid]], "notes", nothing))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_stoichiometry(model::JSONModel, rid::String)::Dict{String,Float64} =
     model.rxns[model.rxn_index[rid]]["metabolites"]
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_name(model::JSONModel, rid::String) =
     get(model.rxns[model.rxn_index[rid]], "name", nothing)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_name(model::JSONModel, mid::String) =
     get(model.mets[model.met_index[mid]], "name", nothing)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.gene_name(model::JSONModel, gid::String) =
     get(model.genes[model.gene_index[gid]], "name", nothing)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.model_annotations(model::JSONModel)::Annotations =
     get(model.json, "annotation", Annotations())
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.model_notes(model::JSONModel)::Notes = get(model.json, "notes", Notes())
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Base.convert(::Type{JSONModel}, mm::AbstractMetabolicModel)
     if typeof(mm) == JSONModel
         return mm

--- a/src/types/models/MATModel.jl
+++ b/src/types/models/MATModel.jl
@@ -13,9 +13,6 @@ end
 Accessors.n_metabolites(m::MATModel)::Int = size(m.mat["S"], 1)
 Accessors.n_variables(m::MATModel)::Int = size(m.mat["S"], 2)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.variables(m::MATModel)::Vector{String}
     if haskey(m.mat, "rxns")
         reshape(m.mat["rxns"], n_variables(m))
@@ -26,16 +23,10 @@ end
 
 Accessors.Internal.@all_variables_are_reactions MATModel
 
-"""
-$(TYPEDSIGNATURES)
-"""
 _mat_has_squashed_coupling(mat) =
     haskey(mat, "A") && haskey(mat, "b") && length(mat["b"]) == size(mat["A"], 1)
 
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.metabolites(m::MATModel)::Vector{String}
     nm = n_metabolites(m)
     if haskey(m.mat, "mets")
@@ -45,22 +36,13 @@ function Accessors.metabolites(m::MATModel)::Vector{String}
     end
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.stoichiometry(m::MATModel) = sparse(m.mat["S"])
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.bounds(m::MATModel) = (
     reshape(get(m.mat, "lb", fill(-Inf, n_variables(m), 1)), n_variables(m)),
     reshape(get(m.mat, "ub", fill(Inf, n_variables(m), 1)), n_variables(m)),
 )
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.balance(m::MATModel)
     b = get(m.mat, "b", spzeros(n_metabolites(m), 1))
     if _mat_has_squashed_coupling(m.mat)
@@ -69,22 +51,13 @@ function Accessors.balance(m::MATModel)
     sparse(reshape(b, n_metabolites(m)))
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.objective(m::MATModel) =
     sparse(reshape(get(m.mat, "c", zeros(n_variables(m), 1)), n_variables(m)))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.coupling(m::MATModel) =
     _mat_has_squashed_coupling(m.mat) ? sparse(m.mat["A"][n_variables(m)+1:end, :]) :
     sparse(get(m.mat, "C", zeros(0, n_variables(m))))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.coupling_bounds(m::MATModel)
     nc = n_coupling_constraints(m)
     if _mat_has_squashed_coupling(m.mat)
@@ -100,17 +73,11 @@ function Accessors.coupling_bounds(m::MATModel)
     end
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.genes(m::MATModel)
     x = get(m.mat, "genes", [])
     reshape(x, length(x))
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.reaction_gene_associations(m::MATModel, rid::String)
     if haskey(m.mat, "grRules")
         grr = m.mat["grRules"][findfirst(==(rid), variables(m))]
@@ -120,9 +87,6 @@ function Accessors.reaction_gene_associations(m::MATModel, rid::String)
     end
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.eval_reaction_gene_association(m::MATModel, rid::String; kwargs...)
     if haskey(m.mat, "grRules")
         grr = m.mat["grRules"][findfirst(==(rid), variables(m))]
@@ -132,17 +96,11 @@ function Accessors.eval_reaction_gene_association(m::MATModel, rid::String; kwar
     end
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_formula(m::MATModel, mid::String) = maybemap(
     x -> parse_formula(x[findfirst(==(mid), metabolites(m))]),
     gets(m.mat, nothing, constants.keynames.metformulas),
 )
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.metabolite_charge(m::MATModel, mid::String)::Maybe{Int}
     met_charge = maybemap(
         x -> x[findfirst(==(mid), metabolites(m))],
@@ -151,9 +109,6 @@ function Accessors.metabolite_charge(m::MATModel, mid::String)::Maybe{Int}
     maybemap(Int, isnan(met_charge) ? nothing : met_charge)
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.metabolite_compartment(m::MATModel, mid::String)
     res = maybemap(
         x -> x[findfirst(==(mid), metabolites(m))],
@@ -168,33 +123,21 @@ function Accessors.metabolite_compartment(m::MATModel, mid::String)
     )
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.reaction_stoichiometry(m::MATModel, rid::String)::Dict{String,Float64}
     ridx = first(indexin([rid], m.mat["rxns"]))[1] # get the index out of the cartesian index
     reaction_stoichiometry(m, ridx)
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.reaction_stoichiometry(m::MATModel, ridx::Int)::Dict{String,Float64}
     met_inds = findall(m.mat["S"][:, ridx] .!= 0.0)
     Dict(m.mat["mets"][met_ind] => m.mat["S"][met_ind, ridx] for met_ind in met_inds)
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_name(m::MATModel, rid::String) = maybemap(
     x -> x[findfirst(==(rid), variables(m))],
     gets(m.mat, nothing, constants.keynames.rxnnames),
 )
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_name(m::MATModel, mid::String) = maybemap(
     x -> x[findfirst(==(mid), metabolites(m))],
     gets(m.mat, nothing, constants.keynames.metnames),
@@ -207,9 +150,6 @@ Accessors.metabolite_name(m::MATModel, mid::String) = maybemap(
 # here are very likely completely incompatible with >50% of the MATLAB models
 # out there.
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Base.convert(::Type{MATModel}, m::AbstractMetabolicModel)
     if typeof(m) == MATModel
         return m

--- a/src/types/models/MATModel.jl
+++ b/src/types/models/MATModel.jl
@@ -15,8 +15,6 @@ Accessors.n_variables(m::MATModel)::Int = size(m.mat["S"], 2)
 
 """
 $(TYPEDSIGNATURES)
-
-Extracts reaction names from `rxns` key in the MAT file.
 """
 function Accessors.variables(m::MATModel)::Vector{String}
     if haskey(m.mat, "rxns")
@@ -30,8 +28,6 @@ Accessors.Internal.@all_variables_are_reactions MATModel
 
 """
 $(TYPEDSIGNATURES)
-
-Guesses whether C in the MAT file is stored in A=[S;C].
 """
 _mat_has_squashed_coupling(mat) =
     haskey(mat, "A") && haskey(mat, "b") && length(mat["b"]) == size(mat["A"], 1)
@@ -39,8 +35,6 @@ _mat_has_squashed_coupling(mat) =
 
 """
 $(TYPEDSIGNATURES)
-
-Extracts metabolite names from `mets` key in the MAT file.
 """
 function Accessors.metabolites(m::MATModel)::Vector{String}
     nm = n_metabolites(m)
@@ -53,15 +47,11 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Extract the stoichiometry matrix, stored under key `S`.
 """
 Accessors.stoichiometry(m::MATModel) = sparse(m.mat["S"])
 
 """
 $(TYPEDSIGNATURES)
-
-Extracts bounds from the MAT file, saved under `lb` and `ub`.
 """
 Accessors.bounds(m::MATModel) = (
     reshape(get(m.mat, "lb", fill(-Inf, n_variables(m), 1)), n_variables(m)),
@@ -70,8 +60,6 @@ Accessors.bounds(m::MATModel) = (
 
 """
 $(TYPEDSIGNATURES)
-
-Extracts balance from the MAT model, defaulting to zeroes if not present.
 """
 function Accessors.balance(m::MATModel)
     b = get(m.mat, "b", spzeros(n_metabolites(m), 1))
@@ -83,16 +71,12 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Extracts the objective from the MAT model (defaults to zeroes).
 """
 Accessors.objective(m::MATModel) =
     sparse(reshape(get(m.mat, "c", zeros(n_variables(m), 1)), n_variables(m)))
 
 """
 $(TYPEDSIGNATURES)
-
-Extract coupling matrix stored, in `C` key.
 """
 Accessors.coupling(m::MATModel) =
     _mat_has_squashed_coupling(m.mat) ? sparse(m.mat["A"][n_variables(m)+1:end, :]) :
@@ -100,8 +84,6 @@ Accessors.coupling(m::MATModel) =
 
 """
 $(TYPEDSIGNATURES)
-
-Extracts the coupling constraints. Currently, there are several accepted ways to store these in MATLAB models; this takes the constraints from vectors `cl` and `cu`.
 """
 function Accessors.coupling_bounds(m::MATModel)
     nc = n_coupling_constraints(m)
@@ -120,8 +102,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Extracts the possible gene list from `genes` key.
 """
 function Accessors.genes(m::MATModel)
     x = get(m.mat, "genes", [])
@@ -130,8 +110,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Extract and parse the associations from `grRules` key, if present.
 """
 function Accessors.reaction_gene_associations(m::MATModel, rid::String)
     if haskey(m.mat, "grRules")
@@ -144,8 +122,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Extract and directly evaluate the associations from `grRules` key, if present.
 """
 function Accessors.eval_reaction_gene_association(m::MATModel, rid::String; kwargs...)
     if haskey(m.mat, "grRules")
@@ -158,8 +134,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Extract metabolite formula from key `metFormula` or `metFormulas`.
 """
 Accessors.metabolite_formula(m::MATModel, mid::String) = maybemap(
     x -> parse_formula(x[findfirst(==(mid), metabolites(m))]),
@@ -168,8 +142,6 @@ Accessors.metabolite_formula(m::MATModel, mid::String) = maybemap(
 
 """
 $(TYPEDSIGNATURES)
-
-Extract metabolite charge from `metCharge` or `metCharges`.
 """
 function Accessors.metabolite_charge(m::MATModel, mid::String)::Maybe{Int}
     met_charge = maybemap(
@@ -181,8 +153,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Extract metabolite compartment from `metCompartment` or `metCompartments`.
 """
 function Accessors.metabolite_compartment(m::MATModel, mid::String)
     res = maybemap(
@@ -200,8 +170,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Return the stoichiometry of reaction with ID `rid`.
 """
 function Accessors.reaction_stoichiometry(m::MATModel, rid::String)::Dict{String,Float64}
     ridx = first(indexin([rid], m.mat["rxns"]))
@@ -210,8 +178,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Return the stoichiometry of reaction at index `ridx`.
 """
 function Accessors.reaction_stoichiometry(m::MATModel, ridx)::Dict{String,Float64}
     met_inds = findall(m.mat["S"][:, ridx] .!= 0.0)
@@ -220,8 +186,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Extract reaction name from `rxnNames`.
 """
 Accessors.reaction_name(m::MATModel, rid::String) = maybemap(
     x -> x[findfirst(==(rid), variables(m))],
@@ -230,8 +194,6 @@ Accessors.reaction_name(m::MATModel, rid::String) = maybemap(
 
 """
 $(TYPEDSIGNATURES)
-
-Extract metabolite name from `metNames`.
 """
 Accessors.metabolite_name(m::MATModel, mid::String) = maybemap(
     x -> x[findfirst(==(mid), metabolites(m))],
@@ -247,8 +209,6 @@ Accessors.metabolite_name(m::MATModel, mid::String) = maybemap(
 
 """
 $(TYPEDSIGNATURES)
-
-Convert any metabolic model to `MATModel`.
 """
 function Base.convert(::Type{MATModel}, m::AbstractMetabolicModel)
     if typeof(m) == MATModel

--- a/src/types/models/MATModel.jl
+++ b/src/types/models/MATModel.jl
@@ -179,7 +179,7 @@ end
 """
 $(TYPEDSIGNATURES)
 """
-function Accessors.reaction_stoichiometry(m::MATModel, ridx)::Dict{String,Float64}
+function Accessors.reaction_stoichiometry(m::MATModel, ridx::Int)::Dict{String,Float64}
     met_inds = findall(m.mat["S"][:, ridx] .!= 0.0)
     Dict(m.mat["mets"][met_ind] => m.mat["S"][met_ind, ridx] for met_ind in met_inds)
 end

--- a/src/types/models/MATModel.jl
+++ b/src/types/models/MATModel.jl
@@ -172,7 +172,7 @@ end
 $(TYPEDSIGNATURES)
 """
 function Accessors.reaction_stoichiometry(m::MATModel, rid::String)::Dict{String,Float64}
-    ridx = first(indexin([rid], m.mat["rxns"]))
+    ridx = first(indexin([rid], m.mat["rxns"]))[1] # get the index out of the cartesian index
     reaction_stoichiometry(m, ridx)
 end
 

--- a/src/types/models/MatrixModel.jl
+++ b/src/types/models/MatrixModel.jl
@@ -49,8 +49,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Get the reactions in a `MatrixModel`.
 """
 Accessors.variables(a::MatrixModel)::Vector{String} = a.rxns
 
@@ -58,45 +56,31 @@ Accessors.Internal.@all_variables_are_reactions MatrixModel
 
 """
 $(TYPEDSIGNATURES)
-
-Metabolites in a `MatrixModel`.
 """
 Accessors.metabolites(a::MatrixModel)::Vector{String} = a.mets
 
 """
 $(TYPEDSIGNATURES)
-
-`MatrixModel` stoichiometry matrix.
 """
 Accessors.stoichiometry(a::MatrixModel)::SparseMat = a.S
 
 """
 $(TYPEDSIGNATURES)
-
-`MatrixModel` flux bounds.
 """
 Accessors.bounds(a::MatrixModel)::Tuple{Vector{Float64},Vector{Float64}} = (a.xl, a.xu)
 
 """
 $(TYPEDSIGNATURES)
-
-`MatrixModel` target flux balance.
 """
 Accessors.balance(a::MatrixModel)::SparseVec = a.b
 
 """
 $(TYPEDSIGNATURES)
-
-`MatrixModel` objective vector.
 """
 Accessors.objective(a::MatrixModel)::SparseVec = a.c
 
 """
 $(TYPEDSIGNATURES)
-
-Collect all genes contained in the [`MatrixModel`](@ref). The call is expensive
-for large models, because the vector is not stored and instead gets rebuilt
-each time this function is called.
 """
 function Accessors.genes(a::MatrixModel)::Vector{String}
     res = Set{String}()
@@ -113,26 +97,18 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Return the stoichiometry of reaction with ID `rid`.
-Accessors."""
+"""
 Accessors.reaction_stoichiometry(m::MatrixModel, rid::String)::Dict{String,Float64} =
     Dict(m.mets[k] => v for (k, v) in zip(findnz(m.S[:, first(indexin([rid], m.rxns))])...))
 
 """
 $(TYPEDSIGNATURES)
-
-Return the stoichiometry of reaction at index `ridx`.
 """
 Accessors.reaction_stoichiometry(m::MatrixModel, ridx)::Dict{String,Float64} =
     Dict(m.mets[k] => v for (k, v) in zip(findnz(m.S[:, ridx])...))
 
 """
 $(TYPEDSIGNATURES)
-
-Retrieve the [`GeneAssociationsDNF`](@ref) from [`MatrixModel`](@ref) by
-reaction index (for [`MatrixModel`](@ref) this is typically faster than
-retrieving by ID).
 """
 Accessors.reaction_gene_associations(
     model::MatrixModel,
@@ -141,9 +117,6 @@ Accessors.reaction_gene_associations(
 
 """
 $(TYPEDSIGNATURES)
-
-Retrieve the [`GeneAssociationsDNF`](@ref) from [`MatrixModel`](@ref) by
-reaction ID.
 """
 Accessors.reaction_gene_associations(
     model::MatrixModel,
@@ -152,8 +125,6 @@ Accessors.reaction_gene_associations(
 
 """
 $(TYPEDSIGNATURES)
-
-Make a `MatrixModel` out of any compatible model type.
 """
 function Base.convert(::Type{MatrixModel}, m::M) where {M<:AbstractMetabolicModel}
     if typeof(m) == MatrixModel

--- a/src/types/models/MatrixModel.jl
+++ b/src/types/models/MatrixModel.jl
@@ -104,7 +104,7 @@ Accessors.reaction_stoichiometry(m::MatrixModel, rid::String)::Dict{String,Float
 """
 $(TYPEDSIGNATURES)
 """
-Accessors.reaction_stoichiometry(m::MatrixModel, ridx::Int64)::Dict{String,Float64} =
+Accessors.reaction_stoichiometry(m::MatrixModel, ridx::Int)::Dict{String,Float64} =
     Dict(m.mets[k] => v for (k, v) in zip(findnz(m.S[:, ridx])...))
 
 """

--- a/src/types/models/MatrixModel.jl
+++ b/src/types/models/MatrixModel.jl
@@ -104,7 +104,7 @@ Accessors.reaction_stoichiometry(m::MatrixModel, rid::String)::Dict{String,Float
 """
 $(TYPEDSIGNATURES)
 """
-Accessors.reaction_stoichiometry(m::MatrixModel, ridx)::Dict{String,Float64} =
+Accessors.reaction_stoichiometry(m::MatrixModel, ridx::Int64)::Dict{String,Float64} =
     Dict(m.mets[k] => v for (k, v) in zip(findnz(m.S[:, ridx])...))
 
 """

--- a/src/types/models/MatrixModel.jl
+++ b/src/types/models/MatrixModel.jl
@@ -47,41 +47,20 @@ mutable struct MatrixModel <: AbstractMetabolicModel
     end
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.variables(a::MatrixModel)::Vector{String} = a.rxns
 
 Accessors.Internal.@all_variables_are_reactions MatrixModel
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolites(a::MatrixModel)::Vector{String} = a.mets
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.stoichiometry(a::MatrixModel)::SparseMat = a.S
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.bounds(a::MatrixModel)::Tuple{Vector{Float64},Vector{Float64}} = (a.xl, a.xu)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.balance(a::MatrixModel)::SparseVec = a.b
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.objective(a::MatrixModel)::SparseVec = a.c
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.genes(a::MatrixModel)::Vector{String}
     res = Set{String}()
     for grr in a.grrs
@@ -95,37 +74,22 @@ function Accessors.genes(a::MatrixModel)::Vector{String}
     sort(collect(res))
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_stoichiometry(m::MatrixModel, rid::String)::Dict{String,Float64} =
     Dict(m.mets[k] => v for (k, v) in zip(findnz(m.S[:, first(indexin([rid], m.rxns))])...))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_stoichiometry(m::MatrixModel, ridx::Int)::Dict{String,Float64} =
     Dict(m.mets[k] => v for (k, v) in zip(findnz(m.S[:, ridx])...))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_gene_associations(
     model::MatrixModel,
     ridx::Int,
 )::Maybe{GeneAssociationsDNF} = model.grrs[ridx]
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_gene_associations(
     model::MatrixModel,
     rid::String,
 )::Maybe{GeneAssociationsDNF} = model.grrs[first(indexin([rid], model.rxns))]
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Base.convert(::Type{MatrixModel}, m::M) where {M<:AbstractMetabolicModel}
     if typeof(m) == MatrixModel
         return m

--- a/src/types/models/ObjectModel.jl
+++ b/src/types/models/ObjectModel.jl
@@ -53,59 +53,21 @@ Base.@kwdef mutable struct ObjectModel <: AbstractMetabolicModel
 end
 
 # AbstractMetabolicModel interface follows
-"""
-$(TYPEDSIGNATURES)
 
-Return a vector of reaction id strings contained in `model`.
-The order of reaction ids returned here matches the order used to construct the
-stoichiometric matrix.
-"""
 Accessors.variables(model::ObjectModel)::StringVecType = collect(keys(model.reactions))
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the number of reactions contained in `model`.
-"""
 Accessors.n_variables(model::ObjectModel)::Int = length(model.reactions)
 
 Accessors.Internal.@all_variables_are_reactions ObjectModel
 
-"""
-$(TYPEDSIGNATURES)
-
-Return a vector of metabolite id strings contained in `model`.
-The order of metabolite strings returned here matches the order used to construct
-the stoichiometric matrix.
-"""
 Accessors.metabolites(model::ObjectModel)::StringVecType = collect(keys(model.metabolites))
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the number of metabolites in `model`.
-"""
 Accessors.n_metabolites(model::ObjectModel)::Int = length(model.metabolites)
 
-"""
-$(TYPEDSIGNATURES)
-
-Return a vector of gene id strings in `model`.
-"""
 Accessors.genes(model::ObjectModel)::StringVecType = collect(keys(model.genes))
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the number of genes in `model`.
-"""
 Accessors.n_genes(model::ObjectModel)::Int = length(model.genes)
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the stoichiometric matrix associated with `model` in sparse format.
-"""
 function Accessors.stoichiometry(model::ObjectModel)::SparseMat
     n_entries = 0
     for (_, r) in model.reactions
@@ -142,37 +104,14 @@ function Accessors.stoichiometry(model::ObjectModel)::SparseMat
     return SparseArrays.sparse(MI, RI, SV, n_metabolites(model), n_variables(model))
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the lower and upper bounds, respectively, for reactions in `model`.
-Order matches that of the reaction ids returned in `variables()`.
-"""
 Accessors.bounds(model::ObjectModel)::Tuple{Vector{Float64},Vector{Float64}} =
     (lower_bounds(model), upper_bounds(model))
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the balance of the linear problem, i.e. b in Sv = 0 where S is the stoichiometric matrix
-and v is the flux vector.
-"""
 Accessors.balance(model::ObjectModel)::SparseVec = spzeros(length(model.metabolites))
 
-"""
-$(TYPEDSIGNATURES)
-
-Return sparse objective vector for `model`.
-"""
 Accessors.objective(model::ObjectModel)::SparseVec =
     sparse([get(model.objective, rid, 0.0) for rid in keys(model.reactions)])
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the gene reaction rule in string format for reaction with `id` in `model`.
-Return `nothing` if not available.
-"""
 function Accessors.reaction_gene_associations(
     model::ObjectModel,
     id::String,
@@ -184,180 +123,60 @@ function Accessors.reaction_gene_associations(
     ]
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the formula of reaction `id` in `model`.
-Return `nothing` if not present.
-"""
 Accessors.metabolite_formula(model::ObjectModel, id::String)::Maybe{MetaboliteFormula} =
     maybemap(parse_formula, model.metabolites[id].formula)
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the charge associated with metabolite `id` in `model`.
-Return nothing if not present.
-"""
 Accessors.metabolite_charge(model::ObjectModel, id::String)::Maybe{Int} =
     model.metabolites[id].charge
 
-"""
-$(TYPEDSIGNATURES)
-
-Return compartment associated with metabolite `id` in `model`.
-Return `nothing` if not present.
-"""
 Accessors.metabolite_compartment(model::ObjectModel, id::String)::Maybe{String} =
     model.metabolites[id].compartment
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the subsystem associated with reaction `id` in `model`.
-Return `nothing` if not present.
-"""
 Accessors.reaction_subsystem(model::ObjectModel, id::String)::Maybe{String} =
     model.reactions[id].subsystem
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the notes associated with metabolite `id` in `model`.
-Return an empty Dict if not present.
-"""
 Accessors.metabolite_notes(model::ObjectModel, id::String)::Maybe{Notes} =
     model.metabolites[id].notes
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the annotation associated with metabolite `id` in `model`.
-Return an empty Dict if not present.
-"""
 Accessors.metabolite_annotations(model::ObjectModel, id::String)::Maybe{Annotations} =
     model.metabolites[id].annotations
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the notes associated with gene `id` in `model`.
-Return an empty Dict if not present.
-"""
 Accessors.gene_notes(model::ObjectModel, gid::String) = model.genes[gid].notes
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the annotation associated with gene `id` in `model`.
-Return an empty Dict if not present.
-"""
 Accessors.gene_annotations(model::ObjectModel, id::String)::Maybe{Annotations} =
     model.genes[id].annotations
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the notes associated with reaction `id` in `model`.
-Return an empty Dict if not present.
-"""
 Accessors.reaction_notes(model::ObjectModel, id::String)::Maybe{Notes} =
     model.reactions[id].notes
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the annotation associated with reaction `id` in `model`.
-Return an empty Dict if not present.
-"""
 Accessors.reaction_annotations(model::ObjectModel, id::String)::Maybe{Annotations} =
     model.reactions[id].annotations
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the stoichiometry of reaction with ID `rid`.
-"""
 Accessors.reaction_stoichiometry(m::ObjectModel, rid::String)::Dict{String,Float64} =
     m.reactions[rid].metabolites
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the name of reaction with ID `id`.
-"""
 Accessors.reaction_name(m::ObjectModel, rid::String) = m.reactions[rid].name
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the name of metabolite with ID `id`.
-"""
 Accessors.metabolite_name(m::ObjectModel, mid::String) = m.metabolites[mid].name
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the name of gene with ID `id`.
-"""
 Accessors.gene_name(m::ObjectModel, gid::String) = m.genes[gid].name
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the molar mass of translated gene with ID `gid`.
-"""
 Accessors.gene_product_molar_mass(model::ObjectModel, gid::String) =
     model.genes[gid].product_molar_mass
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the [`Isozyme`](@ref)s associated with the `model` and reaction `rid`.
-"""
 Accessors.reaction_isozymes(model::ObjectModel, rid::String) =
     model.reactions[rid].gene_associations
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the lower bound of the gene product concentration associated with the `model` and gene `gid`.
-"""
 Accessors.gene_product_lower_bound(model::ObjectModel, gid::String) =
     model.genes[gid].product_lower_bound
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the upper bound of the gene product concentration associated with the `model` and gene `gid`.
-"""
 Accessors.gene_product_upper_bound(model::ObjectModel, gid::String) =
     model.genes[gid].product_upper_bound
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the notes associated with a `model`. At minimum this should include the
-model authors, contact information, and DOI of the associated publication.
-"""
 Accessors.model_notes(model::ObjectModel)::Notes = model.notes
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the annotations associated with a `model`. Typically, these should be
-encoded in MIRIAM format. At minimum it should include the full species name
-with relevant identifiers, taxonomy ID, strain ID, and URL to the genome.
-"""
 Accessors.model_annotations(model::ObjectModel)::Annotations = model.annotations
 
-"""
-$(TYPEDSIGNATURES)
-
-Convert any `AbstractMetabolicModel` into a `ObjectModel`. Note, some data loss
-may occur since only the generic interface is used during the conversion
-process. Additionally, assume the stoichiometry for each gene association is 1.
-"""
 function Base.convert(::Type{ObjectModel}, model::AbstractMetabolicModel)
     if typeof(model) == ObjectModel
         return model

--- a/src/types/models/ObjectModel.jl
+++ b/src/types/models/ObjectModel.jl
@@ -64,9 +64,6 @@ $(TYPEDSIGNATURES)
 """
 Accessors.n_variables(model::ObjectModel)::Int = length(model.reactions)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.Internal.@all_variables_are_reactions ObjectModel
 
 """

--- a/src/types/models/ObjectModel.jl
+++ b/src/types/models/ObjectModel.jl
@@ -54,41 +54,20 @@ end
 
 # AbstractMetabolicModel interface follows
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.variables(model::ObjectModel)::StringVecType = collect(keys(model.reactions))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_variables(model::ObjectModel)::Int = length(model.reactions)
 
 Accessors.Internal.@all_variables_are_reactions ObjectModel
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolites(model::ObjectModel)::StringVecType = collect(keys(model.metabolites))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_metabolites(model::ObjectModel)::Int = length(model.metabolites)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.genes(model::ObjectModel)::StringVecType = collect(keys(model.genes))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_genes(model::ObjectModel)::Int = length(model.genes)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.stoichiometry(model::ObjectModel)::SparseMat
     n_entries = 0
     for (_, r) in model.reactions
@@ -125,26 +104,14 @@ function Accessors.stoichiometry(model::ObjectModel)::SparseMat
     return SparseArrays.sparse(MI, RI, SV, n_metabolites(model), n_variables(model))
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.bounds(model::ObjectModel)::Tuple{Vector{Float64},Vector{Float64}} =
     (lower_bounds(model), upper_bounds(model))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.balance(model::ObjectModel)::SparseVec = spzeros(length(model.metabolites))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.objective(model::ObjectModel)::SparseVec =
     sparse([get(model.objective, rid, 0.0) for rid in keys(model.reactions)])
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.reaction_gene_associations(
     model::ObjectModel,
     id::String,
@@ -156,123 +123,60 @@ function Accessors.reaction_gene_associations(
     ]
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_formula(model::ObjectModel, id::String)::Maybe{MetaboliteFormula} =
     maybemap(parse_formula, model.metabolites[id].formula)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_charge(model::ObjectModel, id::String)::Maybe{Int} =
     model.metabolites[id].charge
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_compartment(model::ObjectModel, id::String)::Maybe{String} =
     model.metabolites[id].compartment
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_subsystem(model::ObjectModel, id::String)::Maybe{String} =
     model.reactions[id].subsystem
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_notes(model::ObjectModel, id::String)::Maybe{Notes} =
     model.metabolites[id].notes
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_annotations(model::ObjectModel, id::String)::Maybe{Annotations} =
     model.metabolites[id].annotations
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.gene_notes(model::ObjectModel, gid::String) = model.genes[gid].notes
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.gene_annotations(model::ObjectModel, id::String)::Maybe{Annotations} =
     model.genes[id].annotations
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_notes(model::ObjectModel, id::String)::Maybe{Notes} =
     model.reactions[id].notes
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_annotations(model::ObjectModel, id::String)::Maybe{Annotations} =
     model.reactions[id].annotations
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_stoichiometry(m::ObjectModel, rid::String)::Dict{String,Float64} =
     m.reactions[rid].metabolites
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_name(m::ObjectModel, rid::String) = m.reactions[rid].name
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_name(m::ObjectModel, mid::String) = m.metabolites[mid].name
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.gene_name(m::ObjectModel, gid::String) = m.genes[gid].name
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.gene_product_molar_mass(model::ObjectModel, gid::String) =
     model.genes[gid].product_molar_mass
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_isozymes(model::ObjectModel, rid::String) =
     model.reactions[rid].gene_associations
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.gene_product_lower_bound(model::ObjectModel, gid::String) =
     model.genes[gid].product_lower_bound
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.gene_product_upper_bound(model::ObjectModel, gid::String) =
     model.genes[gid].product_upper_bound
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.model_notes(model::ObjectModel)::Notes = model.notes
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.model_annotations(model::ObjectModel)::Annotations = model.annotations
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Base.convert(::Type{ObjectModel}, model::AbstractMetabolicModel)
     if typeof(model) == ObjectModel
         return model

--- a/src/types/models/ObjectModel.jl
+++ b/src/types/models/ObjectModel.jl
@@ -54,20 +54,44 @@ end
 
 # AbstractMetabolicModel interface follows
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.variables(model::ObjectModel)::StringVecType = collect(keys(model.reactions))
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.n_variables(model::ObjectModel)::Int = length(model.reactions)
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.Internal.@all_variables_are_reactions ObjectModel
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.metabolites(model::ObjectModel)::StringVecType = collect(keys(model.metabolites))
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.n_metabolites(model::ObjectModel)::Int = length(model.metabolites)
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.genes(model::ObjectModel)::StringVecType = collect(keys(model.genes))
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.n_genes(model::ObjectModel)::Int = length(model.genes)
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function Accessors.stoichiometry(model::ObjectModel)::SparseMat
     n_entries = 0
     for (_, r) in model.reactions
@@ -104,14 +128,26 @@ function Accessors.stoichiometry(model::ObjectModel)::SparseMat
     return SparseArrays.sparse(MI, RI, SV, n_metabolites(model), n_variables(model))
 end
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.bounds(model::ObjectModel)::Tuple{Vector{Float64},Vector{Float64}} =
     (lower_bounds(model), upper_bounds(model))
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.balance(model::ObjectModel)::SparseVec = spzeros(length(model.metabolites))
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.objective(model::ObjectModel)::SparseVec =
     sparse([get(model.objective, rid, 0.0) for rid in keys(model.reactions)])
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function Accessors.reaction_gene_associations(
     model::ObjectModel,
     id::String,
@@ -123,60 +159,123 @@ function Accessors.reaction_gene_associations(
     ]
 end
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.metabolite_formula(model::ObjectModel, id::String)::Maybe{MetaboliteFormula} =
     maybemap(parse_formula, model.metabolites[id].formula)
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.metabolite_charge(model::ObjectModel, id::String)::Maybe{Int} =
     model.metabolites[id].charge
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.metabolite_compartment(model::ObjectModel, id::String)::Maybe{String} =
     model.metabolites[id].compartment
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.reaction_subsystem(model::ObjectModel, id::String)::Maybe{String} =
     model.reactions[id].subsystem
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.metabolite_notes(model::ObjectModel, id::String)::Maybe{Notes} =
     model.metabolites[id].notes
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.metabolite_annotations(model::ObjectModel, id::String)::Maybe{Annotations} =
     model.metabolites[id].annotations
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.gene_notes(model::ObjectModel, gid::String) = model.genes[gid].notes
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.gene_annotations(model::ObjectModel, id::String)::Maybe{Annotations} =
     model.genes[id].annotations
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.reaction_notes(model::ObjectModel, id::String)::Maybe{Notes} =
     model.reactions[id].notes
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.reaction_annotations(model::ObjectModel, id::String)::Maybe{Annotations} =
     model.reactions[id].annotations
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.reaction_stoichiometry(m::ObjectModel, rid::String)::Dict{String,Float64} =
     m.reactions[rid].metabolites
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.reaction_name(m::ObjectModel, rid::String) = m.reactions[rid].name
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.metabolite_name(m::ObjectModel, mid::String) = m.metabolites[mid].name
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.gene_name(m::ObjectModel, gid::String) = m.genes[gid].name
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.gene_product_molar_mass(model::ObjectModel, gid::String) =
     model.genes[gid].product_molar_mass
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.reaction_isozymes(model::ObjectModel, rid::String) =
     model.reactions[rid].gene_associations
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.gene_product_lower_bound(model::ObjectModel, gid::String) =
     model.genes[gid].product_lower_bound
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.gene_product_upper_bound(model::ObjectModel, gid::String) =
     model.genes[gid].product_upper_bound
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.model_notes(model::ObjectModel)::Notes = model.notes
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.model_annotations(model::ObjectModel)::Annotations = model.annotations
 
+"""
+$(TYPEDSIGNATURES)
+"""
 function Base.convert(::Type{ObjectModel}, model::AbstractMetabolicModel)
     if typeof(model) == ObjectModel
         return model

--- a/src/types/models/SBMLModel.jl
+++ b/src/types/models/SBMLModel.jl
@@ -40,8 +40,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Get variables (aka reactions) from a [`SBMLModel`](@ref).
 """
 Accessors.variables(model::SBMLModel)::Vector{String} = model.reaction_ids
 
@@ -49,15 +47,11 @@ Accessors.Internal.@all_variables_are_reactions SBMLModel
 
 """
 $(TYPEDSIGNATURES)
-
-Get metabolites from a [`SBMLModel`](@ref).
 """
 Accessors.metabolites(model::SBMLModel)::Vector{String} = model.metabolite_ids
 
 """
 $(TYPEDSIGNATURES)
-
-Recreate the stoichiometry matrix from the [`SBMLModel`](@ref).
 """
 function Accessors.stoichiometry(model::SBMLModel)::SparseMat
 
@@ -98,9 +92,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Get the lower and upper flux bounds of model [`SBMLModel`](@ref). Throws `DomainError` in
-case if the SBML contains mismatching units.
 """
 function Accessors.bounds(model::SBMLModel)::Tuple{Vector{Float64},Vector{Float64}}
     # There are multiple ways in SBML to specify a lower/upper bound. There are
@@ -157,15 +148,11 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Balance vector of a [`SBMLModel`](@ref). This is always zero.
 """
 Accessors.balance(model::SBMLModel)::SparseVec = spzeros(n_metabolites(model))
 
 """
 $(TYPEDSIGNATURES)
-
-Objective of the [`SBMLModel`](@ref).
 """
 function Accessors.objective(model::SBMLModel)::SparseVec
     res = sparsevec([], [], n_reactions(model))
@@ -191,15 +178,11 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Get genes of a [`SBMLModel`](@ref).
 """
 Accessors.genes(model::SBMLModel)::Vector{String} = model.gene_ids
 
 """
 $(TYPEDSIGNATURES)
-
-Retrieve the reaction gene associations from [`SBMLModel`](@ref).
 """
 Accessors.reaction_gene_associations(
     model::SBMLModel,
@@ -209,8 +192,6 @@ Accessors.reaction_gene_associations(
 
 """
 $(TYPEDSIGNATURES)
-
-Evaluate the gene association formula directly from the SBML Math structure.
 """
 Accessors.eval_reaction_gene_association(model::SBMLModel, rid::String; kwargs...) =
     maybemap(
@@ -220,24 +201,18 @@ Accessors.eval_reaction_gene_association(model::SBMLModel, rid::String; kwargs..
 
 """
 $(TYPEDSIGNATURES)
-
-Get [`MetaboliteFormula`](@ref) from a chosen metabolite from [`SBMLModel`](@ref).
 """
 Accessors.metabolite_formula(model::SBMLModel, mid::String)::Maybe{MetaboliteFormula} =
     maybemap(parse_formula, model.sbml.species[mid].formula)
 
 """
 $(TYPEDSIGNATURES)
-
-Get the compartment of a chosen metabolite from [`SBMLModel`](@ref).
 """
 Accessors.metabolite_compartment(model::SBMLModel, mid::String) =
     model.sbml.species[mid].compartment
 
 """
 $(TYPEDSIGNATURES)
-
-Get charge of a chosen metabolite from [`SBMLModel`](@ref).
 """
 Accessors.metabolite_charge(model::SBMLModel, mid::String)::Maybe{Int} =
     model.sbml.species[mid].charge
@@ -293,8 +268,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Return the stoichiometry of reaction with ID `rid`.
 """
 function Accessors.reaction_stoichiometry(m::SBMLModel, rid::String)::Dict{String,Float64}
     s = Dict{String,Float64}()
@@ -310,45 +283,33 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Return the name of reaction with ID `rid`.
 """
 Accessors.reaction_name(model::SBMLModel, rid::String) = model.sbml.reactions[rid].name
 
 """
 $(TYPEDSIGNATURES)
-
-Return the name of metabolite with ID `mid`.
 """
 Accessors.metabolite_name(model::SBMLModel, mid::String) = model.sbml.species[mid].name
 
 """
 $(TYPEDSIGNATURES)
-
-Return the name of gene with ID `gid`.
 """
 Accessors.gene_name(model::SBMLModel, gid::String) = model.sbml.gene_products[gid].name
 
 """
 $(TYPEDSIGNATURES)
-
-Return the annotations of reaction with ID `rid`.
 """
 Accessors.reaction_annotations(model::SBMLModel, rid::String) =
     _sbml_import_cvterms(model.sbml.reactions[rid].sbo, model.sbml.reactions[rid].cv_terms)
 
 """
 $(TYPEDSIGNATURES)
-
-Return the annotations of metabolite with ID `mid`.
 """
 Accessors.metabolite_annotations(model::SBMLModel, mid::String) =
     _sbml_import_cvterms(model.sbml.species[mid].sbo, model.sbml.species[mid].cv_terms)
 
 """
 $(TYPEDSIGNATURES)
-
-Return the annotations of gene with ID `gid`.
 """
 Accessors.gene_annotations(model::SBMLModel, gid::String) = _sbml_import_cvterms(
     model.sbml.gene_products[gid].sbo,
@@ -357,24 +318,18 @@ Accessors.gene_annotations(model::SBMLModel, gid::String) = _sbml_import_cvterms
 
 """
 $(TYPEDSIGNATURES)
-
-Return the notes about reaction with ID `rid`.
 """
 Accessors.reaction_notes(model::SBMLModel, rid::String) =
     _sbml_import_notes(model.sbml.reactions[rid].notes)
 
 """
 $(TYPEDSIGNATURES)
-
-Return the notes about metabolite with ID `mid`.
 """
 Accessors.metabolite_notes(model::SBMLModel, mid::String) =
     _sbml_import_notes(model.sbml.species[mid].notes)
 
 """
 $(TYPEDSIGNATURES)
-
-Return the notes about gene with ID `gid`.
 """
 Accessors.gene_notes(model::SBMLModel, gid::String) =
     _sbml_import_notes(model.sbml.gene_products[gid].notes)
@@ -382,12 +337,13 @@ Accessors.gene_notes(model::SBMLModel, gid::String) =
 Accessors.model_annotations(model::SBMLModel) =
     _sbml_import_cvterms(model.sbml.sbo, model.sbml.cv_terms)
 
+"""
+$(TYPEDSIGNATURES)
+"""
 Accessors.model_notes(model::SBMLModel) = _sbml_import_notes(model.sbml.notes)
 
 """
 $(TYPEDSIGNATURES)
-
-Convert any metabolic model to [`SBMLModel`](@ref).
 """
 function Base.convert(::Type{SBMLModel}, mm::AbstractMetabolicModel)
     if typeof(mm) == SBMLModel

--- a/src/types/models/SBMLModel.jl
+++ b/src/types/models/SBMLModel.jl
@@ -38,21 +38,12 @@ function SBMLModel(sbml::SBML.Model, active_objective::String = "")
     )
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.variables(model::SBMLModel)::Vector{String} = model.reaction_ids
 
 Accessors.Internal.@all_variables_are_reactions SBMLModel
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolites(model::SBMLModel)::Vector{String} = model.metabolite_ids
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.stoichiometry(model::SBMLModel)::SparseMat
 
     # find the vector size for preallocation
@@ -90,9 +81,6 @@ function Accessors.stoichiometry(model::SBMLModel)::SparseMat
     return sparse(Rows, Cols, Vals, n_metabolites(model), n_reactions(model))
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.bounds(model::SBMLModel)::Tuple{Vector{Float64},Vector{Float64}}
     # There are multiple ways in SBML to specify a lower/upper bound. There are
     # the "global" model bounds that we completely ignore now because no one
@@ -146,14 +134,8 @@ function Accessors.bounds(model::SBMLModel)::Tuple{Vector{Float64},Vector{Float6
     )
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.balance(model::SBMLModel)::SparseVec = spzeros(n_metabolites(model))
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.objective(model::SBMLModel)::SparseVec
     res = sparsevec([], [], n_reactions(model))
 
@@ -176,44 +158,26 @@ function Accessors.objective(model::SBMLModel)::SparseVec
     return res
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.genes(model::SBMLModel)::Vector{String} = model.gene_ids
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_gene_associations(
     model::SBMLModel,
     rid::String,
 )::Maybe{GeneAssociationsDNF} =
     maybemap(parse_grr, model.sbml.reactions[rid].gene_product_association)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.eval_reaction_gene_association(model::SBMLModel, rid::String; kwargs...) =
     maybemap(
         x -> eval_grr(x; kwargs...),
         model.sbml.reactions[rid].gene_product_association,
     )
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_formula(model::SBMLModel, mid::String)::Maybe{MetaboliteFormula} =
     maybemap(parse_formula, model.sbml.species[mid].formula)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_compartment(model::SBMLModel, mid::String) =
     model.sbml.species[mid].compartment
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_charge(model::SBMLModel, mid::String)::Maybe{Int} =
     model.sbml.species[mid].charge
 
@@ -266,9 +230,7 @@ function _sbml_export_notes(notes::Notes)::Maybe{String}
     nothing
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
+
 function Accessors.reaction_stoichiometry(m::SBMLModel, rid::String)::Dict{String,Float64}
     s = Dict{String,Float64}()
     default1(x) = isnothing(x) ? 1 : x
@@ -281,70 +243,37 @@ function Accessors.reaction_stoichiometry(m::SBMLModel, rid::String)::Dict{Strin
     return s
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_name(model::SBMLModel, rid::String) = model.sbml.reactions[rid].name
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_name(model::SBMLModel, mid::String) = model.sbml.species[mid].name
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.gene_name(model::SBMLModel, gid::String) = model.sbml.gene_products[gid].name
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_annotations(model::SBMLModel, rid::String) =
     _sbml_import_cvterms(model.sbml.reactions[rid].sbo, model.sbml.reactions[rid].cv_terms)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_annotations(model::SBMLModel, mid::String) =
     _sbml_import_cvterms(model.sbml.species[mid].sbo, model.sbml.species[mid].cv_terms)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.gene_annotations(model::SBMLModel, gid::String) = _sbml_import_cvterms(
     model.sbml.gene_products[gid].sbo,
     model.sbml.gene_products[gid].cv_terms,
 )
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.reaction_notes(model::SBMLModel, rid::String) =
     _sbml_import_notes(model.sbml.reactions[rid].notes)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.metabolite_notes(model::SBMLModel, mid::String) =
     _sbml_import_notes(model.sbml.species[mid].notes)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.gene_notes(model::SBMLModel, gid::String) =
     _sbml_import_notes(model.sbml.gene_products[gid].notes)
 
 Accessors.model_annotations(model::SBMLModel) =
     _sbml_import_cvterms(model.sbml.sbo, model.sbml.cv_terms)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.model_notes(model::SBMLModel) = _sbml_import_notes(model.sbml.notes)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Base.convert(::Type{SBMLModel}, mm::AbstractMetabolicModel)
     if typeof(mm) == SBMLModel
         return mm

--- a/src/types/models/Serialized.jl
+++ b/src/types/models/Serialized.jl
@@ -20,8 +20,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Unwrap the serialized model (precaching it transparently).
 """
 function Accessors.unwrap_model(m::Serialized)
     precache!(m)
@@ -30,8 +28,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Load the `Serialized` model from disk in case it's not alreadly loaded.
 """
 function Accessors.precache!(model::Serialized)::Nothing
     if isnothing(model.m)

--- a/src/types/models/Serialized.jl
+++ b/src/types/models/Serialized.jl
@@ -18,17 +18,11 @@ mutable struct Serialized{M} <: AbstractModelWrapper where {M<:AbstractMetabolic
         new{T}(model, filename)
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.unwrap_model(m::Serialized)
     precache!(m)
     m.m
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.precache!(model::Serialized)::Nothing
     if isnothing(model.m)
         model.m = deserialize(model.filename)

--- a/src/types/wrappers/EnzymeConstrainedModel.jl
+++ b/src/types/wrappers/EnzymeConstrainedModel.jl
@@ -89,9 +89,10 @@ Accessors.unwrap_model(model::EnzymeConstrainedModel) = model.inner
 """
 $(TYPEDSIGNATURES)
 
-Return a stoichiometry of the [`EnzymeConstrainedModel`](@ref). The enzymatic reactions are
-split into unidirectional forward and reverse ones, each of which may have
-multiple variants per isozyme.
+Return a stoichiometry of the [`EnzymeConstrainedModel`](@ref). The enzymatic
+reactions are split into unidirectional forward and reverse ones, each of which
+may have multiple variants per isozyme. The matrix includes the virtual enzyme
+balances.
 """
 function Accessors.stoichiometry(model::EnzymeConstrainedModel)
     irrevS = stoichiometry(model.inner) * enzyme_constrained_column_reactions(model)
@@ -105,10 +106,8 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Return the objective of the [`EnzymeConstrainedModel`](@ref). Note, the objective is with
-respect to the internal variables, i.e. [`variables(model)`](@ref), which are
-the unidirectional reactions and the genes involved in enzymatic reactions that
-have kinetic data.
+Return the objective of the [`EnzymeConstrainedModel`](@ref). Note, by default
+the objective is inferred from the underlying model.
 """
 Accessors.objective(model::EnzymeConstrainedModel) = model.objective
 
@@ -133,17 +132,12 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Returns the number of all irreversible reactions in `model` as well as the
-number of gene products that take part in enzymatic reactions.
 """
 Accessors.n_variables(model::EnzymeConstrainedModel) =
     length(model.columns) + n_genes(model)
 
 """
 $(TYPEDSIGNATURES)
-
-Return variable bounds for [`EnzymeConstrainedModel`](@ref).
 """
 function Accessors.bounds(model::EnzymeConstrainedModel)
     lbs = [
@@ -212,9 +206,9 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Return the coupling of [`EnzymeConstrainedModel`](@ref). That combines the coupling of the
-wrapped model, coupling for split (arm) reactions, and the coupling for the total
-enzyme capacity.
+Return the coupling of [`EnzymeConstrainedModel`](@ref). That combines the
+coupling of the wrapped model, coupling for split (arm) reactions with enzymes,
+and the coupling for the total enzyme capacity.
 """
 function Accessors.coupling(model::EnzymeConstrainedModel)
     innerC = coupling(model.inner) * enzyme_constrained_column_reactions(model)
@@ -229,9 +223,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Count the coupling constraints in [`EnzymeConstrainedModel`](@ref) (refer to
-[`coupling`](@ref) for details).
 """
 Accessors.n_coupling_constraints(model::EnzymeConstrainedModel) =
     n_coupling_constraints(model.inner) +
@@ -240,9 +231,6 @@ Accessors.n_coupling_constraints(model::EnzymeConstrainedModel) =
 
 """
 $(TYPEDSIGNATURES)
-
-The coupling bounds for [`EnzymeConstrainedModel`](@ref) (refer to [`coupling`](@ref) for
-details).
 """
 function Accessors.coupling_bounds(model::EnzymeConstrainedModel)
     (iclb, icub) = coupling_bounds(model.inner)
@@ -272,8 +260,6 @@ Accessors.balance(model::EnzymeConstrainedModel) =
 
 """
 $(TYPEDSIGNATURES)
-
-Return the number of genes that have enzymatic constraints associated with them.
 """
 Accessors.n_genes(model::EnzymeConstrainedModel) = length(model.coupling_row_gene_product)
 
@@ -295,8 +281,6 @@ Accessors.metabolites(model::EnzymeConstrainedModel) =
 
 """
 $(TYPEDSIGNATURES)
-
-Return the number of metabolites, both real and pseudo, for a [`EnzymeConstrainedModel`](@ref).
 """
 Accessors.n_metabolites(model::EnzymeConstrainedModel) =
     n_metabolites(model.inner) + n_genes(model)

--- a/src/types/wrappers/EnzymeConstrainedModel.jl
+++ b/src/types/wrappers/EnzymeConstrainedModel.jl
@@ -40,17 +40,20 @@ A model with complex enzyme concentration and capacity bounds, as described in
 genome-scale metabolic model by incorporating enzymatic constraints." Molecular
 systems biology 13.8 (2017): 935.*
 
-Use [`make_enzyme_constrained_model`](@ref) or [`with_enzyme_constraints`](@ref) to construct this kind
-of model.
+Use [`make_enzyme_constrained_model`](@ref) or [`with_enzyme_constraints`](@ref)
+to construct this kind of model.
 
 The model wraps another "internal" model, and adds following modifications:
 - enzymatic reactions with known enzyme information are split into multiple
-  forward and reverse variants for each isozyme,
+  forward and reverse variants for each isozyme (affects the stoichiometric
+  matrix),
+- each enzyme reaction may have multiple variants per isozyme, thus the
+  stoichiometric matrix will include all these virtual enzyme balances,
 - reaction coupling is added to ensure the groups of isozyme reactions obey the
-  global reaction flux bounds from the original model,
-- gene concentrations specified by each reaction and its gene product stoichiometry,
-  can constrained by the user to reflect measurements, such as
-  from mass spectrometry,
+  global reaction flux bounds from the original model (affects the coupling),
+- gene concentrations specified by each reaction and its gene product
+  stoichiometry, can constrained by the user to reflect measurements, such as
+  from mass spectrometry (affects the simple bounds),
 - additional coupling is added to simulate total masses of different proteins
   grouped by type (e.g., membrane-bound and free-floating proteins), which can
   be again constrained by the user (this is slightly generalized from original
@@ -60,11 +63,11 @@ The model wraps another "internal" model, and adds following modifications:
 The structure contains fields `columns` that describe the contents of the
 stoichiometry matrix columns, `coupling_row_reaction`,
 `coupling_row_gene_product` and `coupling_row_mass_group` that describe
-correspondence of the coupling rows to original model and determine the
-coupling bounds (note: the coupling for gene product is actually added to
-stoichiometry, not in [`coupling`](@ref)), and `inner`, which is the original
-wrapped model. The `objective` of the model includes also the extra columns for
-individual genes, as held by `coupling_row_gene_product`.
+correspondence of the coupling rows to original model and determine the coupling
+bounds (note: the coupling for gene product is actually added to stoichiometry,
+not in [`coupling`](@ref)), and `inner`, which is the original wrapped model.
+The `objective` of the model includes also the extra columns for individual
+genes, as held by `coupling_row_gene_product`.
 
 Implementation exposes the split reactions (available as `variables(model)`),
 but retains the original "simple" reactions accessible by [`reactions`](@ref).
@@ -86,14 +89,6 @@ end
 
 Accessors.unwrap_model(model::EnzymeConstrainedModel) = model.inner
 
-"""
-$(TYPEDSIGNATURES)
-
-Return a stoichiometry of the [`EnzymeConstrainedModel`](@ref). The enzymatic
-reactions are split into unidirectional forward and reverse ones, each of which
-may have multiple variants per isozyme. The matrix includes the virtual enzyme
-balances.
-"""
 function Accessors.stoichiometry(model::EnzymeConstrainedModel)
     irrevS = stoichiometry(model.inner) * enzyme_constrained_column_reactions(model)
     enzS = enzyme_constrained_gene_product_coupling(model)
@@ -103,21 +98,8 @@ function Accessors.stoichiometry(model::EnzymeConstrainedModel)
     ]
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the objective of the [`EnzymeConstrainedModel`](@ref). Note, by default
-the objective is inferred from the underlying model.
-"""
 Accessors.objective(model::EnzymeConstrainedModel) = model.objective
 
-"""
-$(TYPEDSIGNATURES)
-
-Returns the internal reactions in a [`EnzymeConstrainedModel`](@ref) (these may be split
-to forward- and reverse-only parts with different isozyme indexes; reactions
-IDs are mangled accordingly with suffixes).
-"""
 function Accessors.variables(model::EnzymeConstrainedModel)
     inner_reactions = variables(model.inner)
     mangled_reactions = [
@@ -130,15 +112,9 @@ function Accessors.variables(model::EnzymeConstrainedModel)
     [mangled_reactions; genes(model)]
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_variables(model::EnzymeConstrainedModel) =
     length(model.columns) + n_genes(model)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.bounds(model::EnzymeConstrainedModel)
     lbs = [
         [col.lb for col in model.columns]
@@ -203,13 +179,6 @@ function Accessors.enzyme_group_variables(model::EnzymeConstrainedModel)
     )
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the coupling of [`EnzymeConstrainedModel`](@ref). That combines the
-coupling of the wrapped model, coupling for split (arm) reactions with enzymes,
-and the coupling for the total enzyme capacity.
-"""
 function Accessors.coupling(model::EnzymeConstrainedModel)
     innerC = coupling(model.inner) * enzyme_constrained_column_reactions(model)
     rxnC = enzyme_constrained_reaction_coupling(model)
@@ -221,17 +190,11 @@ function Accessors.coupling(model::EnzymeConstrainedModel)
     ]
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_coupling_constraints(model::EnzymeConstrainedModel) =
     n_coupling_constraints(model.inner) +
     length(model.coupling_row_reaction) +
     length(model.coupling_row_mass_group)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.coupling_bounds(model::EnzymeConstrainedModel)
     (iclb, icub) = coupling_bounds(model.inner)
     (ilb, iub) = bounds(model.inner)
@@ -249,38 +212,16 @@ function Accessors.coupling_bounds(model::EnzymeConstrainedModel)
     )
 end
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the balance of the reactions in the inner model, concatenated with a vector of
-zeros representing the enzyme balance of a [`EnzymeConstrainedModel`](@ref).
-"""
 Accessors.balance(model::EnzymeConstrainedModel) =
     [balance(model.inner); spzeros(length(model.coupling_row_gene_product))]
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_genes(model::EnzymeConstrainedModel) = length(model.coupling_row_gene_product)
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the gene ids of genes that have enzymatic constraints associated with them.
-"""
 Accessors.genes(model::EnzymeConstrainedModel) =
     genes(model.inner)[[idx for (idx, _) in model.coupling_row_gene_product]]
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the ids of all metabolites, both real and pseudo, for a [`EnzymeConstrainedModel`](@ref).
-"""
 Accessors.metabolites(model::EnzymeConstrainedModel) =
     [metabolites(model.inner); genes(model) .* "#enzyme_constrained"]
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_metabolites(model::EnzymeConstrainedModel) =
     n_metabolites(model.inner) + n_genes(model)

--- a/src/types/wrappers/MatrixCoupling.jl
+++ b/src/types/wrappers/MatrixCoupling.jl
@@ -34,30 +34,22 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Get the internal [`MatrixModel`](@ref) out of [`MatrixCoupling`](@ref).
 """
 Accessors.unwrap_model(a::MatrixCoupling) = a.lm
 
 """
 $(TYPEDSIGNATURES)
-
-Coupling constraint matrix for a `MatrixCoupling`.
 """
 Accessors.coupling(a::MatrixCoupling)::SparseMat = vcat(coupling(a.lm), a.C)
 
 """
 $(TYPEDSIGNATURES)
-
-The number of coupling constraints in a `MatrixCoupling`.
 """
 Accessors.n_coupling_constraints(a::MatrixCoupling)::Int =
     n_coupling_constraints(a.lm) + size(a.C, 1)
 
 """
 $(TYPEDSIGNATURES)
-
-Coupling bounds for a `MatrixCoupling`.
 """
 Accessors.coupling_bounds(a::MatrixCoupling)::Tuple{Vector{Float64},Vector{Float64}} =
     vcat.(coupling_bounds(a.lm), (a.cl, a.cu))

--- a/src/types/wrappers/MatrixCoupling.jl
+++ b/src/types/wrappers/MatrixCoupling.jl
@@ -32,33 +32,16 @@ mutable struct MatrixCoupling{M} <: AbstractModelWrapper where {M<:AbstractMetab
     end
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.unwrap_model(a::MatrixCoupling) = a.lm
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.coupling(a::MatrixCoupling)::SparseMat = vcat(coupling(a.lm), a.C)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_coupling_constraints(a::MatrixCoupling)::Int =
     n_coupling_constraints(a.lm) + size(a.C, 1)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.coupling_bounds(a::MatrixCoupling)::Tuple{Vector{Float64},Vector{Float64}} =
     vcat.(coupling_bounds(a.lm), (a.cl, a.cu))
 
-"""
-$(TYPEDSIGNATURES)
-
-Make a `MatrixCoupling` out of any compatible model type.
-"""
 function Base.convert(
     ::Type{MatrixCoupling{M}},
     mm::AbstractMetabolicModel;

--- a/src/types/wrappers/MaxMinDrivingForceModel.jl
+++ b/src/types/wrappers/MaxMinDrivingForceModel.jl
@@ -90,9 +90,6 @@ Accessors.variables(model::MaxMinDrivingForceModel) =
 
 """
 $(TYPEDSIGNATURES)
-
-The number of variables is 1 + the number of metabolites + the number of
-reactions, where the 1 comes from the total max-min driving force.
 """
 Accessors.n_variables(model::MaxMinDrivingForceModel) =
     1 + n_metabolites(model) + n_reactions(model)
@@ -125,8 +122,6 @@ Accessors.objective(model::MaxMinDrivingForceModel) =
 
 """
 $(TYPEDSIGNATURES)
-
-Get the equality constraint rhs of `model`.
 """
 function Accessors.balance(model::MaxMinDrivingForceModel)
     # proton water balance
@@ -155,8 +150,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Get the equality constraint lhs of `model`.
 """
 function Accessors.stoichiometry(model::MaxMinDrivingForceModel)
     var_ids = Internal.original_variables(model)
@@ -206,8 +199,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Get the simple variable bounds of `model`.
 """
 function Accessors.bounds(model::MaxMinDrivingForceModel)
     var_ids = Internal.original_variables(model)
@@ -235,8 +226,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Return the coupling of a max-min driving force model.
 """
 function Accessors.coupling(model::MaxMinDrivingForceModel)
 
@@ -268,8 +257,6 @@ end
 
 """
 $(TYPEDSIGNATURES)
-
-Return the coupling bounds of a max-min driving force model.
 """
 function Accessors.coupling_bounds(model::MaxMinDrivingForceModel)
     n = length(Internal.active_reaction_ids(model))

--- a/src/types/wrappers/MaxMinDrivingForceModel.jl
+++ b/src/types/wrappers/MaxMinDrivingForceModel.jl
@@ -7,10 +7,13 @@ thermodynamics highlights kinetic obstacles in central metabolism.", PLoS
 computational biology, 2014.
 
 When [`flux_balance_analysis`](@ref) is called in this type of model, the
-max-min driving force algorithm is solved. It returns the Gibbs free energy of
-the reactions, the concentrations of metabolites, and the actual maximum minimum
-driving force across all reactions in the model. The optimization problem solved
-is:
+max-min driving force algorithm is solved i.e. the objective of the model is to
+find the maximum minimum Gibbs free energy of reaction across all reactions in
+the model by changing the metabolite concentrations. The variables for max-min
+driving force analysis are the actual maximum minimum driving force of the
+model, the log metabolite concentrations, and the gibbs free energy reaction
+potentials across each reaction. Reaction fluxes are assumed constant.The
+optimization problem solved is:
 ```
 max min -ΔᵣG
 s.t. ΔᵣG = ΔrG⁰ + R T S' ln(C)
@@ -78,19 +81,9 @@ end
 
 Accessors.unwrap_model(model::MaxMinDrivingForceModel) = model.inner
 
-"""
-$(TYPEDSIGNATURES)
-
-The variables for max-min driving force analysis are the actual maximum minimum
-driving force of the model, the log metabolite concentrations, and the gibbs
-free energy reaction potentials across each reaction.
-"""
 Accessors.variables(model::MaxMinDrivingForceModel) =
     ["mmdf"; "log " .* metabolites(model); "ΔG " .* reactions(model)]
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_variables(model::MaxMinDrivingForceModel) =
     1 + n_metabolites(model) + n_reactions(model)
 
@@ -111,18 +104,9 @@ Accessors.gibbs_free_energy_reaction_variables(model::MaxMinDrivingForceModel) =
     Dict(rid => Dict(rid => 1.0) for rid in "ΔG " .* reactions(model))
 
 
-"""
-$(TYPEDSIGNATURES)
-
-For this kind of the model, the objective is the the max-min-driving force which
-is at index 1 in the variables.
-"""
 Accessors.objective(model::MaxMinDrivingForceModel) =
     [1.0; fill(0.0, n_variables(model) - 1)]
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.balance(model::MaxMinDrivingForceModel)
     # proton water balance
     num_proton_water = length(model.proton_ids) + length(model.water_ids)
@@ -148,9 +132,6 @@ function Accessors.balance(model::MaxMinDrivingForceModel)
     ]
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.stoichiometry(model::MaxMinDrivingForceModel)
     var_ids = Internal.original_variables(model)
 
@@ -197,9 +178,6 @@ function Accessors.stoichiometry(model::MaxMinDrivingForceModel)
     ]
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.bounds(model::MaxMinDrivingForceModel)
     var_ids = Internal.original_variables(model)
 
@@ -224,9 +202,6 @@ function Accessors.bounds(model::MaxMinDrivingForceModel)
     return (lbs, ubs)
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.coupling(model::MaxMinDrivingForceModel)
 
     # only constrain reactions that have thermo data
@@ -255,9 +230,6 @@ function Accessors.coupling(model::MaxMinDrivingForceModel)
     ]
 end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 function Accessors.coupling_bounds(model::MaxMinDrivingForceModel)
     n = length(Internal.active_reaction_ids(model))
     neg_dg_lb = fill(-model.max_dg_bound, n)

--- a/src/types/wrappers/SimplifiedEnzymeConstrainedModel.jl
+++ b/src/types/wrappers/SimplifiedEnzymeConstrainedModel.jl
@@ -22,34 +22,37 @@ An enzyme-capacity-constrained model using sMOMENT algorithm, as described by
 *Bekiaris, Pavlos Stephanos, and Steffen Klamt, "Automatic construction of
 metabolic models with enzyme constraints" BMC bioinformatics, 2020*.
 
-Use [`make_simplified_enzyme_constrained_model`](@ref) or [`with_simplified_enzyme_constraints`](@ref) to construct the
-models.
+Use [`make_simplified_enzyme_constrained_model`](@ref) or
+[`with_simplified_enzyme_constraints`](@ref) to construct the models.
 
 The model is constructed as follows:
 - stoichiometry of the original model is retained as much as possible, but
   enzymatic reations are split into forward and reverse parts (marked by a
   suffix like `...#forward` and `...#reverse`),
-- coupling is added to simulate a virtual metabolite "enzyme capacity", which
-  is consumed by all enzymatic reactions at a rate given by enzyme mass divided
-  by the corresponding kcat,
+- coupling is added to simulate a virtual metabolite "enzyme capacity", which is
+  consumed by all enzymatic reactions at a rate given by enzyme mass divided by
+  the corresponding kcat,
 - the total consumption of the enzyme capacity is constrained to a fixed
   maximum.
 
-The `SimplifiedEnzymeConstrainedModel` structure contains a worked-out representation of the
-optimization problem atop a wrapped [`AbstractMetabolicModel`](@ref), in particular the
-separation of certain reactions into unidirectional forward and reverse parts,
-an "enzyme capacity" required for each reaction, and the value of the maximum
-capacity constraint. Original coupling in the inner model is retained.
+The `SimplifiedEnzymeConstrainedModel` structure contains a worked-out
+representation of the optimization problem atop a wrapped
+[`AbstractMetabolicModel`](@ref), in particular the separation of certain
+reactions into unidirectional forward and reverse parts (which changes the
+stoichiometric matrix), an "enzyme capacity" required for each reaction, and the
+value of the maximum capacity constraint. Original coupling in the inner model
+is retained.
 
-In the structure, the field `columns` describes the correspondence of stoichiometry
-columns to the stoichiometry and data of the internal wrapped model, and
-`total_enzyme_capacity` is the total bound on the enzyme capacity consumption
-as specified in sMOMENT algorithm.
+In the structure, the field `columns` describes the correspondence of
+stoichiometry columns to the stoichiometry and data of the internal wrapped
+model, and `total_enzyme_capacity` is the total bound on the enzyme capacity
+consumption as specified in sMOMENT algorithm.
 
 This implementation allows easy access to fluxes from the split reactions
 (available in `variables(model)`), while the original "simple" reactions from
-the wrapped model are retained as [`reactions`](@ref). All additional constraints
-are implemented using [`coupling`](@ref) and [`coupling_bounds`](@ref).
+the wrapped model are retained as [`reactions`](@ref). All additional
+constraints are implemented using [`coupling`](@ref) and
+[`coupling_bounds`](@ref).
 
 # Fields
 $(TYPEDFIELDS)
@@ -63,24 +66,12 @@ end
 
 Accessors.unwrap_model(model::SimplifiedEnzymeConstrainedModel) = model.inner
 
-"""
-$(TYPEDSIGNATURES)
-
-Return a stoichiometry of the [`SimplifiedEnzymeConstrainedModel`](@ref). The enzymatic reactions
-are split into unidirectional forward and reverse ones.
-"""
 Accessors.stoichiometry(model::SimplifiedEnzymeConstrainedModel) =
     stoichiometry(model.inner) * simplified_enzyme_constrained_column_reactions(model)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.objective(model::SimplifiedEnzymeConstrainedModel) =
     simplified_enzyme_constrained_column_reactions(model)' * objective(model.inner)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.variables(model::SimplifiedEnzymeConstrainedModel) =
     let inner_reactions = variables(model.inner)
         [
@@ -91,14 +82,8 @@ Accessors.variables(model::SimplifiedEnzymeConstrainedModel) =
         ]
     end
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_variables(model::SimplifiedEnzymeConstrainedModel) = length(model.columns)
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.bounds(model::SimplifiedEnzymeConstrainedModel) =
     ([col.lb for col in model.columns], [col.ub for col in model.columns])
 
@@ -127,28 +112,14 @@ Accessors.reaction_variables(model::SimplifiedEnzymeConstrainedModel) =
         reaction_variables_matrix(model),
     ) # TODO currently inefficient
 
-"""
-$(TYPEDSIGNATURES)
-
-Return the coupling of a [`SimplifiedEnzymeConstrainedModel`](@ref). This
-combines the coupling of the wrapped model, coupling for split reactions, and
-the coupling for the total enzyme capacity, which is added as a
-[`coupling_bounds`](@ref).
-"""
 Accessors.coupling(model::SimplifiedEnzymeConstrainedModel) = vcat(
     coupling(model.inner) * simplified_enzyme_constrained_column_reactions(model),
     [col.capacity_required for col in model.columns]',
 )
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.n_coupling_constraints(model::SimplifiedEnzymeConstrainedModel) =
     n_coupling_constraints(model.inner) + 1
 
-"""
-$(TYPEDSIGNATURES)
-"""
 Accessors.coupling_bounds(model::SimplifiedEnzymeConstrainedModel) =
     let (iclb, icub) = coupling_bounds(model.inner)
         (vcat(iclb, [0.0]), vcat(icub, [model.total_enzyme_capacity]))

--- a/src/types/wrappers/SimplifiedEnzymeConstrainedModel.jl
+++ b/src/types/wrappers/SimplifiedEnzymeConstrainedModel.jl
@@ -74,18 +74,12 @@ Accessors.stoichiometry(model::SimplifiedEnzymeConstrainedModel) =
 
 """
 $(TYPEDSIGNATURES)
-
-Reconstruct an objective of the [`SimplifiedEnzymeConstrainedModel`](@ref).
 """
 Accessors.objective(model::SimplifiedEnzymeConstrainedModel) =
     simplified_enzyme_constrained_column_reactions(model)' * objective(model.inner)
 
 """
 $(TYPEDSIGNATURES)
-
-Returns the internal reactions in a [`SimplifiedEnzymeConstrainedModel`](@ref) (these may be split
-to forward- and reverse-only parts; reactions IDs are mangled accordingly with
-suffixes).
 """
 Accessors.variables(model::SimplifiedEnzymeConstrainedModel) =
     let inner_reactions = variables(model.inner)
@@ -99,15 +93,11 @@ Accessors.variables(model::SimplifiedEnzymeConstrainedModel) =
 
 """
 $(TYPEDSIGNATURES)
-
-The number of reactions (including split ones) in [`SimplifiedEnzymeConstrainedModel`](@ref).
 """
 Accessors.n_variables(model::SimplifiedEnzymeConstrainedModel) = length(model.columns)
 
 """
 $(TYPEDSIGNATURES)
-
-Return the variable bounds for [`SimplifiedEnzymeConstrainedModel`](@ref).
 """
 Accessors.bounds(model::SimplifiedEnzymeConstrainedModel) =
     ([col.lb for col in model.columns], [col.ub for col in model.columns])
@@ -140,9 +130,10 @@ Accessors.reaction_variables(model::SimplifiedEnzymeConstrainedModel) =
 """
 $(TYPEDSIGNATURES)
 
-Return the coupling of [`SimplifiedEnzymeConstrainedModel`](@ref). That combines the coupling of
-the wrapped model, coupling for split reactions, and the coupling for the total
-enzyme capacity.
+Return the coupling of a [`SimplifiedEnzymeConstrainedModel`](@ref). This
+combines the coupling of the wrapped model, coupling for split reactions, and
+the coupling for the total enzyme capacity, which is added as a
+[`coupling_bounds`](@ref).
 """
 Accessors.coupling(model::SimplifiedEnzymeConstrainedModel) = vcat(
     coupling(model.inner) * simplified_enzyme_constrained_column_reactions(model),
@@ -151,18 +142,12 @@ Accessors.coupling(model::SimplifiedEnzymeConstrainedModel) = vcat(
 
 """
 $(TYPEDSIGNATURES)
-
-Count the coupling constraints in [`SimplifiedEnzymeConstrainedModel`](@ref) (refer to
-[`coupling`](@ref) for details).
 """
 Accessors.n_coupling_constraints(model::SimplifiedEnzymeConstrainedModel) =
     n_coupling_constraints(model.inner) + 1
 
 """
 $(TYPEDSIGNATURES)
-
-The coupling bounds for [`SimplifiedEnzymeConstrainedModel`](@ref) (refer to [`coupling`](@ref) for
-details).
 """
 Accessors.coupling_bounds(model::SimplifiedEnzymeConstrainedModel) =
     let (iclb, icub) = coupling_bounds(model.inner)


### PR DESCRIPTION
Some docstrings are not necessary (especially generic inherited methods). Remove them