### PR TITLE
Fix and extend reconstruction functions and pipes for objectmodel

### DIFF
--- a/docs/src/concepts/1_screen.md
+++ b/docs/src/concepts/1_screen.md
@@ -244,7 +244,7 @@ screen(m,
     analysis = (m,a) -> # `args` elements get passed as the extra parameter here
         flux_balance_analysis_vec(m,
             Tulip.Optimizer;
-            modifications=[change_optimizer_attribute("IPM_IterationsLimit", a)],
+            modifications=[modify_optimizer_attribute("IPM_IterationsLimit", a)],
         ),
 )
 ```

--- a/docs/src/concepts/2_modifications.md
+++ b/docs/src/concepts/2_modifications.md
@@ -10,8 +10,8 @@ list callbacks that do the changes to the prepared optimization model.
 The callbacks available in COBREXA.jl include functions that may help with
 tuning the optimizer, or change the raw values in the linear model, such as:
 
-- [`change_constraint`](@ref) and [`change_objective`](@ref)
-- [`change_sense`](@ref), [`change_optimizer`](@ref), [`change_optimizer_attribute`](@ref)
+- [`modify_constraint`](@ref) and [`change_objective`](@ref)
+- [`modify_sense`](@ref), [`modify_optimizer`](@ref), [`modify_optimizer_attribute`](@ref)
 - [`silence`](@ref)
 - [`knockout`](@ref)
 - [`add_loopless_constraints`](@ref)

--- a/docs/src/examples/04_core_model.jl
+++ b/docs/src/examples/04_core_model.jl
@@ -28,9 +28,9 @@ dict_sol = flux_balance_analysis_dict(
     model,
     Tulip.Optimizer;
     modifications = [
-        change_objective("R_BIOMASS_Ecoli_core_w_GAM"),
-        change_constraint("R_EX_glc__D_e"; lb = -12, ub = -12),
-        change_constraint("R_EX_o2_e"; lb = 0, ub = 0),
+        modify_objective("R_BIOMASS_Ecoli_core_w_GAM"),
+        modify_constraint("R_EX_glc__D_e"; lb = -12, ub = -12),
+        modify_constraint("R_EX_o2_e"; lb = 0, ub = 0),
     ],
 )
 

--- a/docs/src/examples/05b_fba_mods.jl
+++ b/docs/src/examples/05b_fba_mods.jl
@@ -28,11 +28,11 @@ fluxes = flux_balance_analysis_dict(
     model,
     GLPK.Optimizer;
     modifications = [ # modifications are applied in order
-        change_objective("R_BIOMASS_Ecoli_core_w_GAM"), # maximize production
-        change_constraint("R_EX_glc__D_e"; lb = -12, ub = -12), # fix an exchange rate
+        modify_objective("R_BIOMASS_Ecoli_core_w_GAM"), # maximize production
+        modify_constraint("R_EX_glc__D_e"; lb = -12, ub = -12), # fix an exchange rate
         knockout(["b0978", "b0734"]), # knock out two genes
-        change_optimizer(Tulip.Optimizer), # ignore the above optimizer and switch to Tulip
-        change_optimizer_attribute("IPM_IterationsLimit", 1000), # customize Tulip
-        change_sense(JuMP.MAX_SENSE), # explicitly tell Tulip to maximize the objective
+        modify_optimizer(Tulip.Optimizer), # ignore the above optimizer and switch to Tulip
+        modify_optimizer_attribute("IPM_IterationsLimit", 1000), # customize Tulip
+        modify_sense(JuMP.MAX_SENSE), # explicitly tell Tulip to maximize the objective
     ],
 )

--- a/docs/src/examples/06_fva.jl
+++ b/docs/src/examples/06_fva.jl
@@ -35,8 +35,8 @@ min_fluxes, max_fluxes = flux_variability_analysis_dict(
     GLPK.Optimizer;
     bounds = objective_bounds(0.99),
     modifications = [
-        change_constraint("R_EX_glc__D_e"; lb = -10, ub = -10),
-        change_constraint("R_EX_o2_e"; lb = 0.0, ub = 0.0),
+        modify_constraint("R_EX_glc__D_e"; lb = -10, ub = -10),
+        modify_constraint("R_EX_o2_e"; lb = 0.0, ub = 0.0),
     ],
 )
 
@@ -79,8 +79,8 @@ vs = flux_variability_analysis(
     GLPK.Optimizer;
     bounds = objective_bounds(0.50), # objective can vary by up to 50% of the optimum
     modifications = [
-        change_constraint("R_EX_glc__D_e"; lb = -10, ub = -10),
-        change_constraint("R_EX_o2_e"; lb = 0.0, ub = 0.0),
+        modify_constraint("R_EX_glc__D_e"; lb = -10, ub = -10),
+        modify_constraint("R_EX_o2_e"; lb = 0.0, ub = 0.0),
     ],
     ret = optimized_model -> (
         COBREXA.JuMP.objective_value(optimized_model),

--- a/docs/src/examples/07_restricting_reactions.jl
+++ b/docs/src/examples/07_restricting_reactions.jl
@@ -20,7 +20,7 @@ model = load_model(ObjectModel, "e_coli_core.json")
 # (or, alternatively, a pipeable "variant" version
 # [`with_changed_bound`](@ref)).
 #
-# Alternatively, you could utilize [`change_constraint`](@ref) as a
+# Alternatively, you could utilize [`modify_constraint`](@ref) as a
 # modification that acts directly on the JuMP optimization model. That may be
 # useful if you first apply some kind of complicated constraint scheme
 # modification, such as [`add_loopless_constraints`](@ref).
@@ -39,7 +39,7 @@ flux1 = flux_balance_analysis_vec(
 flux2 = flux_balance_analysis_vec(
     model,
     GLPK.Optimizer,
-    modifications = [change_constraint("FBA", lb = 0.0, ub = 0.0)],
+    modifications = [modify_constraint("FBA", lb = 0.0, ub = 0.0)],
 );
 
 # The solutions should not differ a lot:
@@ -55,7 +55,7 @@ original_flux = flux_balance_analysis_dict(model, GLPK.Optimizer);
 restricted_flux = flux_balance_analysis_dict(
     model,
     GLPK.Optimizer,
-    modifications = [change_constraint("EX_o2_e", lb = -0.1, ub = 0.0)],
+    modifications = [modify_constraint("EX_o2_e", lb = -0.1, ub = 0.0)],
 );
 
 # The growth in the restricted case is, expectably, lower than the original one:

--- a/docs/src/examples/08_pfba.jl
+++ b/docs/src/examples/08_pfba.jl
@@ -35,15 +35,15 @@ model = load_model("e_coli_core.xml")
 # Running of basic pFBA is perfectly analogous to running of [FBA](05a_fba.md)
 # and other analyses. We add several modifications that improve the solution
 # (using functions [`silence`](@ref), and
-# [`change_optimizer_attribute`](@ref)), and fix the glucose exchange (using
-# [`change_constraint`](@ref)) in order to get a more reasonable result:
+# [`modify_optimizer_attribute`](@ref)), and fix the glucose exchange (using
+# [`modify_constraint`](@ref)) in order to get a more reasonable result:
 
 fluxes = parsimonious_flux_balance_analysis_dict(
     model,
     Clarabel.Optimizer;
     modifications = [
         silence, # optionally silence the optimizer (Clarabel is very verbose by default)
-        change_constraint("R_EX_glc__D_e"; lb = -12, ub = -12), # fix glucose consumption rate
+        modify_constraint("R_EX_glc__D_e"; lb = -12, ub = -12), # fix glucose consumption rate
     ],
 )
 
@@ -64,11 +64,11 @@ flux_vector = parsimonious_flux_balance_analysis_vec(
     model,
     Tulip.Optimizer; # start with Tulip
     modifications = [
-        change_constraint("R_EX_glc__D_e"; lb = -12, ub = -12),
-        change_optimizer_attribute("IPM_IterationsLimit", 500), # we may change Tulip-specific attributes here
+        modify_constraint("R_EX_glc__D_e"; lb = -12, ub = -12),
+        modify_optimizer_attribute("IPM_IterationsLimit", 500), # we may change Tulip-specific attributes here
     ],
     qp_modifications = [
-        change_optimizer(Clarabel.Optimizer), # now switch to Clarabel (Tulip wouldn't be able to finish the computation)
+        modify_optimizer(Clarabel.Optimizer), # now switch to Clarabel (Tulip wouldn't be able to finish the computation)
         silence, # and make it quiet.
     ],
 )

--- a/docs/src/examples/11_growth.jl
+++ b/docs/src/examples/11_growth.jl
@@ -122,7 +122,7 @@ model_with_bounded_production = change_bound(model, biomass, lower_bound = 0.1) 
 minimal_intake_production = flux_balance_analysis_dict(
     model_with_bounded_production,
     GLPK.Optimizer,
-    modifications = [change_objective(exchanges)],
+    modifications = [modify_objective(exchanges)],
 );
 
 # Metabolite "cost" data may be supplemented using the `weights` argument of

--- a/src/analysis/flux_balance_analysis.jl
+++ b/src/analysis/flux_balance_analysis.jl
@@ -16,8 +16,8 @@ The `optimizer` must be set to a `JuMP`-compatible optimizer, such as
 `GLPK.Optimizer` or `Tulip.Optimizer`
 
 Optionally, you may specify one or more modifications to be applied to the
-model before the analysis, such as [`change_optimizer_attribute`](@ref),
-[`change_objective`](@ref), and [`change_sense`](@ref).
+model before the analysis, such as [`modify_optimizer_attribute`](@ref),
+[`change_objective`](@ref), and [`modify_sense`](@ref).
 
 Returns an optimized `JuMP` model.
 
@@ -30,7 +30,7 @@ value.(solution[:x])  # extract flux steady state from the optimizer
 biomass_reaction_id = findfirst(model.reactions, "BIOMASS_Ecoli_core_w_GAM")
 
 modified_solution = flux_balance_analysis(model, GLPK.optimizer;
-    modifications=[change_objective(biomass_reaction_id)])
+    modifications=[modify_objective(biomass_reaction_id)])
 ```
 """
 function flux_balance_analysis(model::AbstractMetabolicModel, optimizer; modifications = [])

--- a/src/analysis/minimize_metabolic_adjustment.jl
+++ b/src/analysis/minimize_metabolic_adjustment.jl
@@ -28,7 +28,7 @@ optmodel = minimize_metabolic_adjustment(
     model,
     reference_flux,
     Gurobi.Optimizer;
-    modifications = [change_constraint("PFL"; lower_bound=0, upper_bound=0)], # find flux of mutant that is closest to the wild type (reference) model
+    modifications = [modify_constraint("PFL"; lower_bound=0, upper_bound=0)], # find flux of mutant that is closest to the wild type (reference) model
     )
 value.(solution[:x])  # extract the flux from the optimizer
 ```

--- a/src/analysis/modifications/generic.jl
+++ b/src/analysis/modifications/generic.jl
@@ -18,7 +18,7 @@ $(TYPEDSIGNATURES)
 Change the lower and upper bounds (`lower_bound` and `upper_bound` respectively)
 of reaction `id` if supplied.
 """
-change_constraint(id::String; lower_bound = nothing, upper_bound = nothing) =
+modify_constraint(id::String; lower_bound = nothing, upper_bound = nothing) =
     (model, opt_model) -> begin
         ind = first(indexin([id], variables(model)))
         isnothing(ind) && throw(DomainError(id, "No matching reaction was found."))
@@ -36,7 +36,7 @@ $(TYPEDSIGNATURES)
 Change the lower and upper bounds (`lower_bounds` and `upper_bounds`
 respectively) of reactions in `ids` if supplied.
 """
-change_constraints(
+modify_constraints(
     ids::Vector{String};
     lower_bounds = fill(nothing, length(ids)),
     upper_bounds = fill(nothing, length(ids)),
@@ -59,7 +59,7 @@ array of reactions identifiers.
 Optionally, the objective can be weighted by a vector of `weights`, and a
 optimization `sense` can be set to either `MAX_SENSE` or `MIN_SENSE`.
 """
-change_objective(
+modify_objective(
     new_objective::Union{String,Vector{String}};
     weights = [],
     sense = MAX_SENSE,

--- a/src/analysis/modifications/optimizer.jl
+++ b/src/analysis/modifications/optimizer.jl
@@ -8,7 +8,7 @@ Possible arguments are `MAX_SENSE` and `MIN_SENSE`.
 If you want to change the objective and sense at the same time, use
 [`change_objective`](@ref) instead to do both at once.
 """
-change_sense(objective_sense) =
+modify_sense(objective_sense) =
     (_, opt_model) -> set_objective_sense(opt_model, objective_sense)
 
 """
@@ -20,7 +20,7 @@ This may be used to try different approaches for reaching the optimum, and in
 problems that may require different optimizers for different parts, such as the
 [`parsimonious_flux_balance_analysis`](@ref).
 """
-change_optimizer(optimizer) = (_, opt_model) -> set_optimizer(opt_model, optimizer)
+modify_optimizer(optimizer) = (_, opt_model) -> set_optimizer(opt_model, optimizer)
 
 """
 $(TYPEDSIGNATURES)
@@ -29,7 +29,7 @@ Change a JuMP optimizer attribute. The attributes are optimizer-specific, refer
 to the JuMP documentation and the documentation of the specific optimizer for
 usable keys and values.
 """
-change_optimizer_attribute(attribute_key, value) =
+modify_optimizer_attribute(attribute_key, value) =
     (_, opt_model) -> set_optimizer_attribute(opt_model, attribute_key, value)
 
 """

--- a/src/analysis/screening.jl
+++ b/src/analysis/screening.jl
@@ -222,7 +222,7 @@ Both the modification functions (in vectors) and the analysis function here
 have 2 base parameters (as opposed to 1 with [`screen`](@ref)): first is the
 `model` (carried through as-is), second is the prepared JuMP optimization model
 that may be modified and acted upon. As an example, you can use modification
-[`change_constraint`](@ref) and analysis [`screen_optimize_objective`](@ref).
+[`modify_constraint`](@ref) and analysis [`screen_optimize_objective`](@ref).
 
 Note: This function is a thin argument-handling wrapper around
 [`_screen_optmodel_modifications_impl`](@ref).

--- a/src/analysis/variability_analysis.jl
+++ b/src/analysis/variability_analysis.jl
@@ -188,9 +188,9 @@ mins, maxs = flux_variability_analysis_dict(
     Tulip.Optimizer;
     bounds = objective_bounds(0.99),
     modifications = [
-        change_optimizer_attribute("IPM_IterationsLimit", 500),
-        change_constraint("EX_glc__D_e"; lower_bound = -10, upper_bound = -10),
-        change_constraint("EX_o2_e"; lower_bound = 0, upper_bound = 0),
+        modify_optimizer_attribute("IPM_IterationsLimit", 500),
+        modify_constraint("EX_glc__D_e"; lower_bound = -10, upper_bound = -10),
+        modify_constraint("EX_o2_e"; lower_bound = 0, upper_bound = 0),
     ],
 )
 ```

--- a/src/misc/check_keys.jl
+++ b/src/misc/check_keys.jl
@@ -4,7 +4,8 @@ Throw an ArgumentError if model.field has any keys in xs::Union{Reaction, Metabo
 function throw_argerror_if_key_found(model, field, xs)
     _ids = collect(keys(getfield(model, field)))
     ids = [x.id for x in xs if x.id in _ids]
-    isempty(ids) || throw(ArgumentError("Duplicated $field IDs already present in model: $ids"))
+    isempty(ids) ||
+        throw(ArgumentError("Duplicated $field IDs already present in model: $ids"))
     nothing
 end
 
@@ -15,5 +16,14 @@ function throw_argerror_if_key_missing(model, field, xs::Vector{String})
     _ids = collect(keys(getfield(model, field)))
     ids = [x for x in xs if !(x in _ids)]
     isempty(ids) || throw(ArgumentError("Missing $field IDs in model: $ids"))
+    nothing
+end
+
+"""
+Throw and ArgumentError if rxn_ids have isozymes associated with them.
+"""
+function throw_argerror_if_isozymes_found(model, rxn_ids)
+    ids = filter(!isnothing, r.gene_associations for r in model.reactions[rxn_ids])
+    isempty(ids) || throw(ArgumentError("Isozymes already assign to reactions: $ids"))
     nothing
 end

--- a/src/misc/check_keys.jl
+++ b/src/misc/check_keys.jl
@@ -23,7 +23,7 @@ end
 Throw and ArgumentError if rxn_ids have isozymes associated with them.
 """
 function throw_argerror_if_isozymes_found(model, rxn_ids)
-    ids = filter(!isnothing, r.gene_associations for r in model.reactions[rxn_ids])
+    ids = [rid for rid in rxn_ids if !isnothing(model.reactions[rid].gene_associations)]
     isempty(ids) || throw(ArgumentError("Isozymes already assign to reactions: $ids"))
     nothing
 end

--- a/src/misc/check_keys.jl
+++ b/src/misc/check_keys.jl
@@ -1,0 +1,19 @@
+"""
+Throw an ArgumentError if model.field has any keys in xs::Union{Reaction, Metabolite, Gene}.
+"""
+function throw_argerror_if_key_found(model, field, xs)
+    _ids = collect(keys(getfield(model, field)))
+    ids = [x.id for x in xs if x.id in _ids]
+    isempty(ids) || throw(ArgumentError("Duplicated $field IDs already present in model: $ids"))
+    nothing
+end
+
+"""
+Throw an ArgumentError if model.field does not have any keys in xs.
+"""
+function throw_argerror_if_key_missing(model, field, xs::Vector{String})
+    _ids = collect(keys(getfield(model, field)))
+    ids = [x for x in xs if !(x in _ids)]
+    isempty(ids) || throw(ArgumentError("Missing $field IDs in model: $ids"))
+    nothing
+end

--- a/src/moduletools.jl
+++ b/src/moduletools.jl
@@ -50,7 +50,7 @@ macro reexport(mods...)
             Base.isexported($modulename, sym) || continue
             typeof($(Expr(:., modulename, :sym))) == Module && continue
             sym in [:eval, :include] && continue
-            @eval const $(Expr(:$, :sym)) = ($modulename).$(Expr(:$, :sym))
+            @eval $(Expr(:$, :sym)) = ($modulename).$(Expr(:$, :sym))
             @eval export $(Expr(:$, :sym))
         end
     end)

--- a/src/moduletools.jl
+++ b/src/moduletools.jl
@@ -50,7 +50,7 @@ macro reexport(mods...)
             Base.isexported($modulename, sym) || continue
             typeof($(Expr(:., modulename, :sym))) == Module && continue
             sym in [:eval, :include] && continue
-            @eval $(Expr(:$, :sym)) = ($modulename).$(Expr(:$, :sym))
+            @eval const $(Expr(:$, :sym)) = ($modulename).$(Expr(:$, :sym))
             @eval export $(Expr(:$, :sym))
         end
     end)

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -13,7 +13,11 @@ using ..ModuleTools
 @dse
 
 using ..Accessors
-using ..Internal: constants, throw_argerror_if_key_found, throw_argerror_if_key_missing
+using ..Internal:
+    constants,
+    throw_argerror_if_key_found,
+    throw_argerror_if_key_missing,
+    throw_argerror_if_isozymes_found
 using ..Internal.Macros
 using ..Log.Internal
 using ..Types

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -15,9 +15,13 @@ using ..ModuleTools
 using ..Accessors
 using ..Internal:
     constants,
-    throw_argerror_if_key_found,
-    throw_argerror_if_key_missing,
-    throw_argerror_if_isozymes_found
+    check_arg_keys_exists,
+    check_arg_keys_missing,
+    check_has_isozymes,
+    check_has_biomass_rxn_id,
+    check_biomass_rxn_has_isozymes,
+    check_has_virtualribosome,
+    check_has_biomass_rxn_biomas_metabolite
 using ..Internal.Macros
 using ..Log.Internal
 using ..Types

--- a/src/reconstruction.jl
+++ b/src/reconstruction.jl
@@ -13,7 +13,7 @@ using ..ModuleTools
 @dse
 
 using ..Accessors
-using ..Internal: constants
+using ..Internal: constants, throw_argerror_if_key_found, throw_argerror_if_key_missing
 using ..Internal.Macros
 using ..Log.Internal
 using ..Types

--- a/src/reconstruction/ObjectModel.jl
+++ b/src/reconstruction/ObjectModel.jl
@@ -1,13 +1,19 @@
+# Add and remove reactions
+
 """
 $(TYPEDSIGNATURES)
 
 Add `rxns` to `model` based on reaction `id`.
 """
 function add_reactions!(model::ObjectModel, rxns::Vector{Reaction})
+    rxn_ids = collect(keys(model.reactions))
+    idxs = filter(!isnothing, indexin([r.id for r in rxns], rxn_ids))
+    isempty(idxs) ||
+        throw(ArgumentError("Duplicated reaction IDs in model: $(rxn_ids[idxs])"))
+
     for rxn in rxns
         model.reactions[rxn.id] = rxn
     end
-    nothing
 end
 
 """
@@ -30,7 +36,7 @@ function add_reactions(model::ObjectModel, rxns::Vector{Reaction})
         m.reactions[rxn.id] = rxn
     end
 
-    return m
+    m
 end
 
 """
@@ -40,16 +46,47 @@ Add `rxn` to `model`, and return a shallow copied version of the model.
 """
 add_reaction(model::ObjectModel, rxn::Reaction) = add_reactions(model, [rxn])
 
+@_remove_fn reaction ObjectModel String inplace begin
+    if !(reaction_id in variables(model))
+        @models_log @info "Reaction $reaction_id not found in model."
+    else
+        delete!(model.reactions, reaction_id)
+    end
+    nothing
+end
+
+@_remove_fn reaction ObjectModel String inplace plural begin
+    remove_reaction!.(Ref(model), reaction_ids)
+    nothing
+end
+
+@_remove_fn reaction ObjectModel String begin
+    remove_reactions(model, [reaction_id])
+end
+
+@_remove_fn reaction ObjectModel String plural begin
+    n = copy(model)
+    n.reactions = copy(model.reactions)
+    remove_reactions!(n, reaction_ids)
+    return n
+end
+
+# Add and remove metabolites
+
 """
 $(TYPEDSIGNATURES)
 
 Add `mets` to `model` based on metabolite `id`.
 """
 function add_metabolites!(model::ObjectModel, mets::Vector{Metabolite})
+    met_ids = collect(keys(model.metabolites))
+    idxs = filter(!isnothing, indexin([m.id for m in mets], met_ids))
+    isempty(idxs) ||
+        throw(ArgumentError("Duplicated metabolite IDs in model: $(met_ids[idxs])"))
+
     for met in mets
         model.metabolites[met.id] = met
     end
-    nothing
 end
 
 """
@@ -72,7 +109,7 @@ function add_metabolites(model::ObjectModel, mets::Vector{Metabolite})
         m.metabolites[met.id] = met
     end
 
-    return m
+    m
 end
 
 """
@@ -82,16 +119,51 @@ Add `met` to `model` and return a shallow copied version of the model.
 """
 add_metabolite(model::ObjectModel, met::Metabolite) = add_metabolites(model, [met])
 
+@_remove_fn metabolite ObjectModel String inplace begin
+    remove_metabolites!(model, [metabolite_id])
+end
+
+@_remove_fn metabolite ObjectModel String inplace plural begin
+    !all(in.(metabolite_ids, Ref(metabolites(model)))) &&
+        @models_log @info "Some metabolites not found in model."
+    remove_reactions!(
+        model,
+        [
+            rid for (rid, rn) in model.reactions if
+            any(haskey.(Ref(rn.metabolites), metabolite_ids))
+        ],
+    )
+    delete!.(Ref(model.metabolites), metabolite_ids)
+    nothing
+end
+
+@_remove_fn metabolite ObjectModel String begin
+    remove_metabolites(model, [metabolite_id])
+end
+
+@_remove_fn metabolite ObjectModel String plural begin
+    n = copy(model)
+    n.reactions = copy(model.reactions)
+    n.metabolites = copy(model.metabolites)
+    remove_metabolites!(n, metabolite_ids)
+    return n
+end
+
+# Add and remove genes
+
 """
 $(TYPEDSIGNATURES)
 
 Add `genes` to `model` based on gene `id`.
 """
 function add_genes!(model::ObjectModel, genes::Vector{Gene})
+    gene_ids = collect(keys(model.genes))
+    idxs = filter(!isnothing, indexin([g.id for g in genes], gene_ids))
+    isempty(idxs) || throw(ArgumentError("Duplicated gene IDs in model: $(gene_ids[idxs])"))
+
     for gene in genes
         model.genes[gene.id] = gene
     end
-    nothing
 end
 
 """
@@ -114,7 +186,7 @@ function add_genes(model::ObjectModel, genes::Vector{Gene})
         m.genes[gn.id] = gn
     end
 
-    return m
+    m
 end
 
 """
@@ -170,6 +242,8 @@ remove_gene!(model, "g1")
 remove_gene!(model::ObjectModel, gid::String; knockout_reactions::Bool = false) =
     remove_genes!(model, [gid]; knockout_reactions = knockout_reactions)
 
+# Change reaction bounds
+
 @_change_bounds_fn ObjectModel String inplace begin
     isnothing(lower_bound) || (model.reactions[rxn_id].lower_bound = lower_bound)
     isnothing(upper_bound) || (model.reactions[rxn_id].upper_bound = upper_bound)
@@ -204,317 +278,7 @@ end
     return n
 end
 
-@_remove_fn reaction ObjectModel String inplace begin
-    if !(reaction_id in variables(model))
-        @models_log @info "Reaction $reaction_id not found in model."
-    else
-        delete!(model.reactions, reaction_id)
-    end
-    nothing
-end
-
-@_remove_fn reaction ObjectModel String inplace plural begin
-    remove_reaction!.(Ref(model), reaction_ids)
-    nothing
-end
-
-@_remove_fn reaction ObjectModel String begin
-    remove_reactions(model, [reaction_id])
-end
-
-@_remove_fn reaction ObjectModel String plural begin
-    n = copy(model)
-    n.reactions = copy(model.reactions)
-    remove_reactions!(n, reaction_ids)
-    return n
-end
-
-@_remove_fn metabolite ObjectModel String inplace begin
-    remove_metabolites!(model, [metabolite_id])
-end
-
-@_remove_fn metabolite ObjectModel String inplace plural begin
-    !all(in.(metabolite_ids, Ref(metabolites(model)))) &&
-        @models_log @info "Some metabolites not found in model."
-    remove_reactions!(
-        model,
-        [
-            rid for (rid, rn) in model.reactions if
-            any(haskey.(Ref(rn.metabolites), metabolite_ids))
-        ],
-    )
-    delete!.(Ref(model.metabolites), metabolite_ids)
-    nothing
-end
-
-@_remove_fn metabolite ObjectModel String begin
-    remove_metabolites(model, [metabolite_id])
-end
-
-@_remove_fn metabolite ObjectModel String plural begin
-    n = copy(model)
-    n.reactions = copy(model.reactions)
-    n.metabolites = copy(model.metabolites)
-    remove_metabolites!(n, metabolite_ids)
-    return n
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Change the objective for `model` to reaction(s) with `rxn_ids`, optionally
-specifying their `weights`. By default, assume equal weights. If no objective
-exists in model, sets objective.
-"""
-function change_objective!(
-    model::ObjectModel,
-    rxn_ids::Vector{String};
-    weights = ones(length(rxn_ids)),
-)
-    all(!haskey(model.reactions, rid) for rid in rxn_ids) &&
-        throw(DomainError(rxn_ids, "Some reaction ids were not found in model."))
-    model.objective = Dict(rxn_ids .=> weights)
-    nothing
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Variant of [`change_objective!`](@ref) that sets a single `rxn_id` as the
-objective weight with `weight` (defaults to 1.0).
-"""
-change_objective!(model::ObjectModel, rxn_id::String; weight::Float64 = 1.0) =
-    change_objective!(model, [rxn_id]; weights = [weight])
-
-"""
-$(TYPEDSIGNATURES)
-
-Variant of [`change_objective!`](@ref) that does not modify the original model,
-but makes a shallow copy with the modification included.
-"""
-function change_objective(
-    model::ObjectModel,
-    rxn_ids::Vector{String};
-    weights = ones(length(rxn_ids)),
-)
-    m = copy(model)
-    m.objective = copy(model.objective)
-    change_objective!(m, rxn_ids; weights)
-    m
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Variant of [`change_objective!`](@ref) that does not modify the original model,
-but makes a shallow copy with the modification included.
-"""
-function change_objective(model::ObjectModel, rxn_id::String; weight::Float64 = 1.0)
-    m = copy(model)
-    m.objective = copy(model.objective)
-    change_objective!(m, rxn_id; weight)
-    m
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Add a biomass metabolite called `biomass_metabolite_id` with stoichiometry 1 to
-the biomass reaction, called `biomass_rxn_id` in `model`. Changes the model in
-place.
-"""
-function add_biomass_metabolite!(
-    model::ObjectModel,
-    biomass_rxn_id::String;
-    biomass_metabolite_id = "biomass",
-)
-    model.reactions[biomass_rxn_id].metabolites[biomass_metabolite_id] = 1.0
-    add_metabolite!(model, Metabolite(biomass_metabolite_id))
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Variant of [`add_biomass_metabolite!`](@ref) that does not modify the original
-model, but makes a shallow copy with the modification included.
-"""
-function add_biomass_metabolite(
-    model::ObjectModel,
-    biomass_rxn_id::String;
-    biomass_metabolite_id = "biomass",
-)
-    m = copy(model)
-    m.metabolites = copy(m.metabolites)
-    m.metabolites[biomass_metabolite_id] = Metabolite(biomass_metabolite_id)
-
-    m.reactions = copy(model.reactions)
-    m.reactions[biomass_rxn_id] = copy(model.reactions[biomass_rxn_id])
-    m.reactions[biomass_rxn_id].metabolites =
-        copy(model.reactions[biomass_rxn_id].metabolites)
-    m.reactions[biomass_rxn_id].metabolites[biomass_metabolite_id] = 1.0
-
-    m
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-To `biomass_rxn_id` in `model`, add a pseudo-isozyme that approximates the
-effect ribosome synthesis has on growth.
-
-# Bacterial growth law models
-Numerous experimental studies have shown that during steady state growth the
-cellular density of E. coli (and probably other bacteria) is constant. As a
-consequence of this, growth law models typically assume that the total proteome
-capacity (mass fraction of protein in the cell) is limited. Further, it has been
-shown experimentally that the ribosomal protein content of a bacterial cell
-increases with faster growth rate. Ribosomes are used to make proteins (and
-themselves), leading to a trade-off: faster growth requires more ribosomes to
-make more enzymes to grow, but this reduces the amount of proteome space "left
-over" for biosynthetic enzymes. See Mori, Matteo, et al. "Constrained allocation
-flux balance analysis." PLoS computational biology 12.6 (2016) for more details.
-
-# Implementation
-By adding a protein cost to biomass synthesis this effect can be simulated. The
-parameter `weight` needs to be estimated from data, but acts like a turnover
-number. Lower `weight` means more ribosome is required for growth (`ribosome =
-growth/weight`). The molar mass of the ribosome is `1`.
-
-# Note
-1. This modifications makes the underlying biomass reaction unidirectional.
-2. The `virtualribosome_id` defaults to `virtualribosome` and must be manually included
-   in any capacity bound later used in enzyme constrained models.
-3. This modification also adds a pseudogene called `virtualribosome_id`.
-
-The pseudo-isozyme acts like a regular gene product,
-```
-ribosome = weight * biomass_flux
-```
-"""
-function add_virtualribosome!(
-    model::ObjectModel,
-    biomass_rxn_id::String,
-    weight::Float64;
-    virtualribosome_id = "virtualribosome",
-)
-    # ensure unidirectional
-    model.reactions[biomass_rxn_id].lower_bound = 0.0
-    model.reactions[biomass_rxn_id].upper_bound = constants.default_reaction_bound
-
-    # add ribosome kinetics
-    model.reactions[biomass_rxn_id].gene_associations = [
-        Isozyme(
-            kcat_forward = weight,
-            kcat_backward = 0.0,
-            gene_product_stoichiometry = Dict(virtualribosome_id => 1.0),
-        ),
-    ]
-
-    # add ribosome gene
-    model.genes[virtualribosome_id] =
-        Gene(id = virtualribosome_id, product_molar_mass = 1.0)
-
-    nothing
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Variant of [`add_virtualribosome!`](@ref) that does not modify the original
-model, but makes a shallow copy with the modification included.
-"""
-function add_virtualribosome(
-    model::ObjectModel,
-    biomass_rxn_id::String,
-    weight::Float64;
-    virtualribosome_id = "virtualribosome",
-)
-    m = copy(model)
-    m.reactions = copy(model.reactions)
-    m.reactions[biomass_rxn_id] = copy(model.reactions[biomass_rxn_id])
-    m.genes = copy(model.genes)
-
-    add_virtualribosome!(m, biomass_rxn_id, weight; virtualribosome_id)
-
-    m
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Add `isozymes` to `rxn_id` in `model`. Overwrites the currently stored isozymes. Assumes genes
-are already in `model`.
-"""
-add_isozymes!(model::ObjectModel, rxn_id::String, isozymes::Vector{Isozyme}) =
-    model.reactions[rxn_id].gene_associations = isozymes
-
-"""
-$(TYPEDSIGNATURES)
-
-For each pair of `isozymes` and `rxn_id` in `isozymes_vector` and
-`rxn_id_vector`, call [`add_isozymes!`](@ref) to add the isozymes to the
-`model`.
-"""
-function add_isozymes!(
-    model::ObjectModel,
-    rxn_id_vector::Vector{String},
-    isozymes_vector::Vector{Vector{Isozyme}},
-)
-    for (rid, isozymes) in zip(rxn_id_vector, isozymes_vector)
-        add_isozymes!(model, rid, isozymes)
-    end
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Variant of [`add_isozymes!`](@ref) that returns a copied model instead of
-modifying the input.
-"""
-function add_isozymes(model::ObjectModel, rxn_id::String, isozymes::Vector{Isozyme})
-
-    m = copy(model)
-    m.reactions = copy(model.reactions)
-
-    m.reactions[rxn_id] = copy(model.reactions[rxn_id])
-    if !isnothing(model.reactions[rxn_id].gene_associations)
-        m.reactions[rxn_id].gene_associations =
-            copy(model.reactions[rxn_id].gene_associations)
-    end
-    m.reactions[rxn_id].gene_associations = isozymes
-
-    m
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-For each pair of `isozymes` and `rxn_id` in `isozymes_vector` and
-`rxn_id_vector`, call [`add_isozymes`](@ref) to add the isozymes to the
-`model`.
-"""
-function add_isozymes(
-    model::ObjectModel,
-    rxn_id_vector::Vector{String},
-    isozymes_vector::Vector{Vector{Isozyme}},
-)
-
-    m = copy(model)
-    m.reactions = copy(model.reactions)
-
-    for (rxn_id, isozymes) in zip(rxn_id_vector, isozymes_vector)
-
-        m.reactions[rxn_id] = copy(model.reactions[rxn_id])
-        if !isnothing(model.reactions[rxn_id].gene_associations)
-            m.reactions[rxn_id].gene_associations =
-                copy(model.reactions[rxn_id].gene_associations)
-        end
-        m.reactions[rxn_id].gene_associations = isozymes
-
-    end
-
-    m
-end
+# Change gene product bounds
 
 """
 $(TYPEDSIGNATURES)
@@ -602,4 +366,314 @@ function change_gene_product_bound(
         lower_bounds = [lower_bound],
         upper_bounds = [upper_bound],
     )
+end
+
+# Change objective 
+
+"""
+$(TYPEDSIGNATURES)
+
+Change the objective for `model` to reaction(s) with `rxn_ids`, optionally
+specifying their `weights`. By default, assume equal weights. If no objective
+exists in model, sets objective.
+"""
+function change_objective!(
+    model::ObjectModel,
+    rxn_ids::Vector{String};
+    weights = ones(length(rxn_ids)),
+)
+    all(!haskey(model.reactions, rid) for rid in rxn_ids) &&
+        throw(DomainError(rxn_ids, "Some reaction ids were not found in model."))
+    model.objective = Dict(rxn_ids .=> weights)
+    nothing
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Variant of [`change_objective!`](@ref) that sets a single `rxn_id` as the
+objective weight with `weight` (defaults to 1.0).
+"""
+change_objective!(model::ObjectModel, rxn_id::String; weight::Float64 = 1.0) =
+    change_objective!(model, [rxn_id]; weights = [weight])
+
+"""
+$(TYPEDSIGNATURES)
+
+Variant of [`change_objective!`](@ref) that does not modify the original model,
+but makes a shallow copy with the modification included.
+"""
+function change_objective(
+    model::ObjectModel,
+    rxn_ids::Vector{String};
+    weights = ones(length(rxn_ids)),
+)
+    m = copy(model)
+    m.objective = copy(model.objective)
+    change_objective!(m, rxn_ids; weights)
+    m
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Variant of [`change_objective!`](@ref) that does not modify the original model,
+but makes a shallow copy with the modification included.
+"""
+function change_objective(model::ObjectModel, rxn_id::String; weight::Float64 = 1.0)
+    m = copy(model)
+    m.objective = copy(model.objective)
+    change_objective!(m, rxn_id; weight)
+    m
+end
+
+# Add and remove biomass metabolite
+
+"""
+$(TYPEDSIGNATURES)
+
+Add a biomass metabolite called `biomass_metabolite_id` with stoichiometry 1 to
+the biomass reaction, called `biomass_rxn_id` in `model`. Changes the model in
+place. Does not check if the model already has a biomass metabolite.
+"""
+function add_biomass_metabolite!(
+    model::ObjectModel,
+    biomass_rxn_id::String;
+    biomass_metabolite_id = "biomass",
+)
+    model.reactions[biomass_rxn_id].metabolites[biomass_metabolite_id] = 1.0
+    add_metabolite!(model, Metabolite(biomass_metabolite_id))
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Variant of [`add_biomass_metabolite!`](@ref) that does not modify the original
+model, but makes a shallow copy with the modification included. Does not check
+if the model already has a biomass metabolite.
+"""
+function add_biomass_metabolite(
+    model::ObjectModel,
+    biomass_rxn_id::String;
+    biomass_metabolite_id = "biomass",
+)
+    m = copy(model)
+    m.metabolites = copy(m.metabolites)
+    m.metabolites[biomass_metabolite_id] = Metabolite(biomass_metabolite_id)
+
+    m.reactions = copy(model.reactions)
+    m.reactions[biomass_rxn_id] = copy(model.reactions[biomass_rxn_id])
+    m.reactions[biomass_rxn_id].metabolites =
+        copy(model.reactions[biomass_rxn_id].metabolites)
+    m.reactions[biomass_rxn_id].metabolites[biomass_metabolite_id] = 1.0
+
+    m
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Remove a biomass metabolite called `biomass_metabolite_id` from
+the biomass reaction, called `biomass_rxn_id` in `model`. 
+"""
+function remove_biomass_metabolite!(
+    model::ObjectModel,
+    biomass_rxn_id::String;
+    biomass_metabolite_id = "biomass",
+)
+    delete!(model.reactions[biomass_rxn_id].metabolites, biomass_metabolite_id)
+    remove_metabolite!(model, biomass_metabolite_id)
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Variant of [`remove_biomass_metabolite!`](@ref) that does not modify the original
+model, but makes a shallow copy with the modification included.
+"""
+function remove_biomass_metabolite(
+    model::ObjectModel,
+    biomass_rxn_id::String;
+    biomass_metabolite_id = "biomass",
+)
+    m = copy(model)
+    m.metabolites = copy(m.metabolites)
+    remove_metabolite!(m, biomass_metabolite_id)
+
+    m.reactions = copy(model.reactions)
+    m.reactions[biomass_rxn_id] = copy(model.reactions[biomass_rxn_id])
+    m.reactions[biomass_rxn_id].metabolites =
+        copy(model.reactions[biomass_rxn_id].metabolites)
+    delete!(m.reactions[biomass_rxn_id].metabolites, biomass_metabolite_id)
+
+    m
+end
+
+# Add virtual ribosome for constrained allocation applications
+
+"""
+$(TYPEDSIGNATURES)
+
+To `biomass_rxn_id` in `model`, add a pseudo-isozyme that approximates the
+effect ribosome synthesis has on growth.
+
+# Bacterial growth law models
+Numerous experimental studies have shown that during steady state growth the
+cellular density of E. coli (and probably other bacteria) is constant. As a
+consequence of this, growth law models typically assume that the total proteome
+capacity (mass fraction of protein in the cell) is limited. Further, it has been
+shown experimentally that the ribosomal protein content of a bacterial cell
+increases with faster growth rate. Ribosomes are used to make proteins (and
+themselves), leading to a trade-off: faster growth requires more ribosomes to
+make more enzymes to grow, but this reduces the amount of proteome space "left
+over" for biosynthetic enzymes. See Mori, Matteo, et al. "Constrained allocation
+flux balance analysis." PLoS computational biology 12.6 (2016) for more details.
+
+# Implementation
+By adding a protein cost to biomass synthesis this effect can be simulated. The
+parameter `weight` needs to be estimated from data, but acts like a turnover
+number. Lower `weight` means more ribosome is required for growth (`ribosome =
+growth/weight`). The molar mass of the ribosome is `1`.
+
+# Note
+1. This modifications makes the underlying biomass reaction unidirectional.
+2. The `virtualribosome_id` defaults to `virtualribosome` and must be manually included
+   in any capacity bound later used in enzyme constrained models.
+3. This modification also adds a pseudogene called `virtualribosome_id`.
+
+The pseudo-isozyme acts like a regular gene product,
+```
+ribosome = weight * biomass_flux
+```
+"""
+function add_virtualribosome!(
+    model::ObjectModel,
+    biomass_rxn_id::String,
+    weight::Float64;
+    virtualribosome_id = "virtualribosome",
+)
+    # ensure unidirectional
+    model.reactions[biomass_rxn_id].lower_bound = 0.0
+    model.reactions[biomass_rxn_id].upper_bound = constants.default_reaction_bound
+
+    # add ribosome kinetics
+    model.reactions[biomass_rxn_id].gene_associations = [
+        Isozyme(
+            kcat_forward = weight,
+            kcat_backward = 0.0,
+            gene_product_stoichiometry = Dict(virtualribosome_id => 1.0),
+        ),
+    ]
+
+    # add ribosome gene
+    model.genes[virtualribosome_id] =
+        Gene(id = virtualribosome_id, product_molar_mass = 1.0)
+
+    nothing
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Variant of [`add_virtualribosome!`](@ref) that does not modify the original
+model, but makes a shallow copy with the modification included.
+"""
+function add_virtualribosome(
+    model::ObjectModel,
+    biomass_rxn_id::String,
+    weight::Float64;
+    virtualribosome_id = "virtualribosome",
+)
+    m = copy(model)
+    m.reactions = copy(model.reactions)
+    m.reactions[biomass_rxn_id] = copy(model.reactions[biomass_rxn_id])
+    m.genes = copy(model.genes)
+
+    add_virtualribosome!(m, biomass_rxn_id, weight; virtualribosome_id)
+
+    m
+end
+
+# Add, change, remove isozymes
+
+"""
+$(TYPEDSIGNATURES)
+
+Add `isozymes` to `rxn_id` in `model`.
+"""
+add_isozymes!(model::ObjectModel, rxn_id::String, isozymes::Vector{Isozyme}) =
+    add_isozymes!(model, [rxn_id], [isozymes])
+
+"""
+$(TYPEDSIGNATURES)
+
+For each reaction in `rxn_ids`, add the corresponding isozymes in
+`isozymes_vector` to `model`.
+"""
+function add_isozymes!(
+    model::ObjectModel,
+    rxn_ids::Vector{String},
+    isozymes_vector::Vector{Vector{Isozyme}},
+)
+    rxn_ids = keys(model.reactions)
+    idxs = filter(!isnothing, indexin(rxns, rxn_ids))
+    isempty(idxs) ||
+        throw(ArgumentError("Duplicated reaction IDs in model: $(rxn_ids[idxs])"))
+    isnothing(model.reactions[rxn_id].gene_associations) ||
+        throw(ArgumentError("$rxn_id already has isozymes."))
+
+    for (rid, isozymes) in zip(rxn_id_vector, isozymes_vector)
+        add_isozymes!(model, rid, isozymes)
+    end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Variant of [`add_isozymes!`](@ref) that returns a copied model instead of
+modifying the input.
+"""
+function add_isozymes(model::ObjectModel, rxn_id::String, isozymes::Vector{Isozyme})
+
+    m = copy(model)
+    m.reactions = copy(model.reactions)
+
+    m.reactions[rxn_id] = copy(model.reactions[rxn_id])
+    if !isnothing(model.reactions[rxn_id].gene_associations)
+        m.reactions[rxn_id].gene_associations =
+            copy(model.reactions[rxn_id].gene_associations)
+    end
+    m.reactions[rxn_id].gene_associations = isozymes
+
+    m
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+For each pair of `isozymes` and `rxn_id` in `isozymes_vector` and
+`rxn_id_vector`, call [`add_isozymes`](@ref) to add the isozymes to the
+`model`.
+"""
+function add_isozymes(
+    model::ObjectModel,
+    rxn_id_vector::Vector{String},
+    isozymes_vector::Vector{Vector{Isozyme}},
+)
+
+    m = copy(model)
+    m.reactions = copy(model.reactions)
+
+    for (rxn_id, isozymes) in zip(rxn_id_vector, isozymes_vector)
+
+        m.reactions[rxn_id] = copy(model.reactions[rxn_id])
+        if !isnothing(model.reactions[rxn_id].gene_associations)
+            m.reactions[rxn_id].gene_associations =
+                copy(model.reactions[rxn_id].gene_associations)
+        end
+        m.reactions[rxn_id].gene_associations = isozymes
+
+    end
+
+    m
 end

--- a/src/reconstruction/ObjectModel.jl
+++ b/src/reconstruction/ObjectModel.jl
@@ -3,8 +3,7 @@
 """
 $(TYPEDSIGNATURES)
 
-Add `rxns` to `model` based on reaction `id` if the `id` is not already in the
-model.
+Plural variant of [`add_reaction!`](@ref).
 """
 function add_reactions!(model::ObjectModel, rxns::Vector{Reaction})
     throw_argerror_if_key_found(model, :reactions, rxns)
@@ -17,15 +16,14 @@ end
 $(TYPEDSIGNATURES)
 
 Add `rxn` to `model` based on reaction `id` if the `id` is not already in the
-model
+model.
 """
 add_reaction!(model::ObjectModel, rxn::Reaction) = add_reactions!(model, [rxn])
 
 """
 $(TYPEDSIGNATURES)
 
-Add `rxns` to `model` and return a shallow copied version of the model. Only
-adds the `rxns` if their IDs are not already present in the model.
+Plural variant of [`add_reaction`](@ref).
 """
 function add_reactions(model::ObjectModel, rxns::Vector{Reaction})
     m = copy(model)
@@ -37,15 +35,10 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Add `rxn` to `model`, and return a shallow copied version of the model. Only
-adds the `rxn` if its ID is not already present in the model.
+Return a shallow copied version of `model` with `rxn` added if it's ID is not
+already present in the model.
 """
 add_reaction(model::ObjectModel, rxn::Reaction) = add_reactions(model, [rxn])
-
-@_remove_fn reaction ObjectModel String inplace begin
-    remove_reactions!(model, [reaction_id])
-    nothing
-end
 
 @_remove_fn reaction ObjectModel String inplace plural begin
     throw_argerror_if_key_missing(model, :reactions, reaction_ids)
@@ -53,8 +46,9 @@ end
     nothing
 end
 
-@_remove_fn reaction ObjectModel String begin
-    remove_reactions(model, [reaction_id])
+@_remove_fn reaction ObjectModel String inplace begin
+    remove_reactions!(model, [reaction_id])
+    nothing
 end
 
 @_remove_fn reaction ObjectModel String plural begin
@@ -64,13 +58,16 @@ end
     return n
 end
 
+@_remove_fn reaction ObjectModel String begin
+    remove_reactions(model, [reaction_id])
+end
+
 # Add and remove metabolites
 
 """
 $(TYPEDSIGNATURES)
 
-Add `mets` to `model` based on metabolite `id` if the `id` is not already in the
-model.
+Plural variant of [`add_metabolite!`](@ref).
 """
 function add_metabolites!(model::ObjectModel, mets::Vector{Metabolite})
     throw_argerror_if_key_found(model, :metabolites, mets)
@@ -90,8 +87,7 @@ add_metabolite!(model::ObjectModel, met::Metabolite) = add_metabolites!(model, [
 """
 $(TYPEDSIGNATURES)
 
-Add `mets` to `model` and return a shallow copied version of the model. Only
-adds the `mets` if their IDs are not already present in the model.
+Plural variant of [`add_metabolite`](@ref).
 """
 function add_metabolites(model::ObjectModel, mets::Vector{Metabolite})
     m = copy(model)
@@ -103,14 +99,10 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Add `met` to `model` and return a shallow copied version of the model.  Only
-adds the `met` if its ID is not already present in the model.
+Return a shallow copied version of the `model` with `met` added.  Only adds
+`met` if its ID is not already present in the model.
 """
 add_metabolite(model::ObjectModel, met::Metabolite) = add_metabolites(model, [met])
-
-@_remove_fn metabolite ObjectModel String inplace begin
-    remove_metabolites!(model, [metabolite_id])
-end
 
 @_remove_fn metabolite ObjectModel String inplace plural begin
     throw_argerror_if_key_missing(model, :metabolites, metabolite_ids)
@@ -125,8 +117,8 @@ end
     nothing
 end
 
-@_remove_fn metabolite ObjectModel String begin
-    remove_metabolites(model, [metabolite_id])
+@_remove_fn metabolite ObjectModel String inplace begin
+    remove_metabolites!(model, [metabolite_id])
 end
 
 @_remove_fn metabolite ObjectModel String plural begin
@@ -137,13 +129,16 @@ end
     return n
 end
 
+@_remove_fn metabolite ObjectModel String begin
+    remove_metabolites(model, [metabolite_id])
+end
+
 # Add and remove genes
 
 """
 $(TYPEDSIGNATURES)
 
-Add `genes` to `model` based on gene `id` if the `id` is not already in the
-model.
+Plural variant of [`add_gene!`](@ref).
 """
 function add_genes!(model::ObjectModel, genes::Vector{Gene})
     throw_argerror_if_key_found(model, :genes, genes)
@@ -163,8 +158,7 @@ add_gene!(model::ObjectModel, gene::Gene) = add_genes!(model, [gene])
 """
 $(TYPEDSIGNATURES)
 
-Add `genes` to `model` and return a shallow copied version of the model.  Only
-adds the `genes` if their IDs are not already present in the model.
+Plural variant of [`add_gene`](@ref).
 """
 function add_genes(model::ObjectModel, genes::Vector{Gene})
     m = copy(model)
@@ -176,27 +170,21 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Add `gene` to `model` and return a shallow copied version of the model.  Only
-adds the `gene` if its ID is not already present in the model.
+Return a shallow copied version of the `model` with added `gene`. Only adds the
+`gene` if its ID is not already present in the model.
 """
 add_gene(model::ObjectModel, gene::Gene) = add_genes(model, [gene])
 
 """
 $(TYPEDSIGNATURES)
 
-Remove all genes with `ids` from `model`. If `knockout_reactions` is true, then also
-constrain reactions that require the genes to function to carry zero flux.
-
-# Example
-```
-remove_genes!(model, ["g1", "g2"])
-```
+Plural variant of [`remove_gene!`](@ref).
 """
 function remove_genes!(
     model::ObjectModel,
     gids::Vector{String};
     knockout_reactions::Bool = false,
-)   
+)
     throw_argerror_if_key_missing(model, :genes, gids)
     if knockout_reactions
         rm_reactions = String[]
@@ -219,11 +207,6 @@ $(TYPEDSIGNATURES)
 
 Remove gene with `id` from `model`. If `knockout_reactions` is true, then also
 constrain reactions that require the genes to function to carry zero flux.
-
-# Example
-```
-remove_gene!(model, "g1")
-```
 """
 remove_gene!(model::ObjectModel, gid::String; knockout_reactions::Bool = false) =
     remove_genes!(model, [gid]; knockout_reactions = knockout_reactions)
@@ -231,14 +214,19 @@ remove_gene!(model::ObjectModel, gid::String; knockout_reactions::Bool = false) 
 # Change reaction bounds
 
 @_change_bounds_fn ObjectModel String inplace begin
-    isnothing(lower_bound) || (model.reactions[rxn_id].lower_bound = lower_bound)
-    isnothing(upper_bound) || (model.reactions[rxn_id].upper_bound = upper_bound)
-    nothing
+    change_bounds!(
+        model,
+        [rxn_id];
+        lower_bounds = [lower_bound],
+        upper_bounds = [upper_bound],
+    )
 end
 
 @_change_bounds_fn ObjectModel String inplace plural begin
-    for (i, l, u) in zip(rxn_ids, lower_bounds, upper_bounds)
-        change_bound!(model, i, lower_bound = l, upper_bound = u)
+    throw_argerror_if_key_missing(model, :reactions, rxn_ids)
+    for (rxn_id, lower, upper) in zip(rxn_ids, lower_bounds, upper_bounds)
+        isnothing(lower) || (model.reactions[rxn_id].lower_bound = lower)
+        isnothing(upper) || (model.reactions[rxn_id].upper_bound = upper)
     end
 end
 
@@ -252,16 +240,18 @@ end
 end
 
 @_change_bounds_fn ObjectModel String plural begin
-    n = copy(model)
-    n.reactions = copy(model.reactions)
-    for rid in rxn_ids
-        n.reactions[rid] = copy(model.reactions[rid])
+    throw_argerror_if_key_missing(model, :reactions, rxn_ids)
+    m = copy(model)
+    m.reactions = copy(model.reactions)
+    for (rid, lower, upper) in zip(rxn_ids, lower_bounds, upper_bounds)
+        m.reactions[rid] = copy(model.reactions[rid])
         for field in fieldnames(typeof(model.reactions[rid]))
-            setfield!(n.reactions[rid], field, getfield(model.reactions[rid], field))
+            setfield!(m.reactions[rid], field, getfield(model.reactions[rid], field))
         end
+        isnothing(lower) || (m.reactions[rxn_id].lower_bound = lower)
+        isnothing(upper) || (m.reactions[rxn_id].upper_bound = upper)
     end
-    change_bounds!(n, rxn_ids; lower_bounds, upper_bounds)
-    return n
+    return m
 end
 
 # Change gene product bounds
@@ -269,8 +259,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Changes the `product_lower_bound` or `product_upper_bound` for the
-[`Gene`][(ref)s listed in `gids` in the `model`, in place.
+Plural variant of [`change_gene_product_bound!`](@ref).
 """
 function change_gene_product_bounds!(
     model::ObjectModel,
@@ -278,15 +267,10 @@ function change_gene_product_bounds!(
     lower_bounds = fill(nothing, length(gids)),
     upper_bounds = fill(nothing, length(gids)),
 )
-    for (i, gid) in enumerate(gids)
-
-        isnothing(lower_bounds[i]) || begin
-            (model.genes[gid].product_lower_bound = lower_bounds[i])
-        end
-
-        isnothing(upper_bounds[i]) || begin
-            (model.genes[gid].product_upper_bound = upper_bounds[i])
-        end
+    throw_argerror_if_key_missing(model, :genes, gids)
+    for (gid, lower, upper) in zip(gids, lower_bounds, upper_bounds)
+        isnothing(lower) || (model.genes[gid].product_lower_bound = lower)
+        isnothing(upper) || (model.genes[gid].product_upper_bound = upper)
     end
 end
 
@@ -294,7 +278,8 @@ end
 $(TYPEDSIGNATURES)
 
 Changes the `product_lower_bound` or `product_upper_bound` for the
-[`Gene`][(ref) `gid` in the `model`, in place.
+[`Gene`][(ref) `gid` in the `model`, in place. If either `lower_bound` or
+`upper_bound` is `nothing`, then that bound is not changed.
 """
 function change_gene_product_bound!(
     model::ObjectModel,
@@ -313,8 +298,7 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Variant of [`change_gene_product_bounds!`](@ref) that does not modify the
-original model, but makes a shallow copy with the modification included.
+Plural variant of [`change_gene_product_bound`](@ref).
 """
 function change_gene_product_bounds(
     model::ObjectModel,
@@ -322,15 +306,17 @@ function change_gene_product_bounds(
     lower_bounds = fill(nothing, length(gids)),
     upper_bounds = fill(nothing, length(gids)),
 )
+    throw_argerror_if_key_missing(model, :genes, gids)
     m = copy(model)
     m.genes = copy(model.genes)
-    for gid in gids
+    for (gid, lower, upper) in zip(gids, lower_bounds, upper_bounds)
         m.genes[gid] = copy(model.genes[gid])
-        for field in fieldnames(typeof(m.genes[gid]))
+        for field in fieldnames(typeof(model.genes[gid]))
             setfield!(m.genes[gid], field, getfield(model.genes[gid], field))
         end
+        isnothing(lower) || (model.genes[gid].product_lower_bound = lower)
+        isnothing(upper) || (model.genes[gid].product_upper_bound = upper)
     end
-    change_gene_product_bounds!(m, gids; lower_bounds, upper_bounds)
     m
 end
 
@@ -400,6 +386,7 @@ function change_objective(
     m
 end
 
+
 """
 $(TYPEDSIGNATURES)
 
@@ -427,6 +414,8 @@ function add_biomass_metabolite!(
     biomass_rxn_id::String;
     biomass_metabolite_id = "biomass",
 )
+    haskey(model.reactions, biomass_rxn_id) ||
+        throw(ArgumentError("$biomass_rxn_id not found in model."))
     model.reactions[biomass_rxn_id].metabolites[biomass_metabolite_id] = 1.0
     add_metabolite!(model, Metabolite(biomass_metabolite_id))
 end
@@ -443,6 +432,9 @@ function add_biomass_metabolite(
     biomass_rxn_id::String;
     biomass_metabolite_id = "biomass",
 )
+    haskey(model.reactions, biomass_rxn_id) ||
+        throw(ArgumentError("$biomass_rxn_id not found in model."))
+
     m = copy(model)
     m.metabolites = copy(m.metabolites)
     m.metabolites[biomass_metabolite_id] = Metabolite(biomass_metabolite_id)
@@ -467,6 +459,11 @@ function remove_biomass_metabolite!(
     biomass_rxn_id::String;
     biomass_metabolite_id = "biomass",
 )
+    haskey(model.reactions, biomass_rxn_id) ||
+        throw(ArgumentError("$biomass_rxn_id not found in model."))
+    haskey(model.reaction[biomass_rxn_id], biomass_metabolite_id) ||
+        throw(ArgumentError("$biomass_metabolite_id not found in $biomass_rxn_id."))
+
     delete!(model.reactions[biomass_rxn_id].metabolites, biomass_metabolite_id)
     remove_metabolite!(model, biomass_metabolite_id)
 end
@@ -482,9 +479,14 @@ function remove_biomass_metabolite(
     biomass_rxn_id::String;
     biomass_metabolite_id = "biomass",
 )
+    haskey(model.reactions, biomass_rxn_id) ||
+        throw(ArgumentError("$biomass_rxn_id not found in model."))
+    haskey(model.reaction[biomass_rxn_id], biomass_metabolite_id) ||
+        throw(ArgumentError("$biomass_metabolite_id not found in $biomass_rxn_id."))
+
     m = copy(model)
     m.metabolites = copy(m.metabolites)
-    remove_metabolite!(m, biomass_metabolite_id)
+    delete!(m.metabolites, biomass_metabolite_id)
 
     m.reactions = copy(model.reactions)
     m.reactions[biomass_rxn_id] = copy(model.reactions[biomass_rxn_id])
@@ -495,13 +497,13 @@ function remove_biomass_metabolite(
     m
 end
 
-# Add virtual ribosome for constrained allocation applications
+# Add virtual ribosome (assume no model already has one)
 
 """
 $(TYPEDSIGNATURES)
 
-To `biomass_rxn_id` in `model`, add a pseudo-isozyme that approximates the
-effect ribosome synthesis has on growth.
+To `biomass_rxn_id` in `model`, add a pseudo-isozyme and associated gene that
+approximates the effect ribosome synthesis has on growth.
 
 # Bacterial growth law models
 Numerous experimental studies have shown that during steady state growth the
@@ -516,21 +518,16 @@ over" for biosynthetic enzymes. See Mori, Matteo, et al. "Constrained allocation
 flux balance analysis." PLoS computational biology 12.6 (2016) for more details.
 
 # Implementation
-By adding a protein cost to biomass synthesis this effect can be simulated. The
-parameter `weight` needs to be estimated from data, but acts like a turnover
-number. Lower `weight` means more ribosome is required for growth (`ribosome =
-growth/weight`). The molar mass of the ribosome is `1`.
-
-# Note
-1. This modifications makes the underlying biomass reaction unidirectional.
-2. The `virtualribosome_id` defaults to `virtualribosome` and must be manually included
-   in any capacity bound later used in enzyme constrained models.
-3. This modification also adds a pseudogene called `virtualribosome_id`.
-
-The pseudo-isozyme acts like a regular gene product,
+This modification makes the underlying biomass reaction unidirectional. The
+`virtualribosome_id` defaults to `virtualribosome`, and corresponds to a
+pseudogene called `virtualribosome_id`. The parameter `weight` needs to be
+estimated from data, but acts like a turnover number. Lower `weight` means more
+ribosome is required for growth (`ribosome = growth/weight`). The molar mass of
+the ribosome is `1`. The pseudo-isozyme acts like a regular gene product,
 ```
 ribosome = weight * biomass_flux
 ```
+when simulating enzyme constrained models.
 """
 function add_virtualribosome!(
     model::ObjectModel,
@@ -538,6 +535,13 @@ function add_virtualribosome!(
     weight::Float64;
     virtualribosome_id = "virtualribosome",
 )
+    haskey(model.reactions, biomass_rxn_id) ||
+        throw(ArgumentError("$biomass_rxn_id not found in model."))
+    isnothing(model.reactions[biomass_rxn_id]) ||
+        throw(ArgumentError("$biomass_rxn_id already has isozymes associated to it."))
+    haskey(model.genes, virtualribosome_id) ||
+        throw(ArgumentError("$virtualribosome_id already found in model."))
+
     # ensure unidirectional
     model.reactions[biomass_rxn_id].lower_bound = 0.0
     model.reactions[biomass_rxn_id].upper_bound = constants.default_reaction_bound
@@ -570,6 +574,13 @@ function add_virtualribosome(
     weight::Float64;
     virtualribosome_id = "virtualribosome",
 )
+    haskey(model.reactions, biomass_rxn_id) ||
+        throw(ArgumentError("$biomass_rxn_id not found in model."))
+    isnothing(model.reactions[biomass_rxn_id]) ||
+        throw(ArgumentError("$biomass_rxn_id already has isozymes associated to it."))
+    haskey(model.genes, virtualribosome_id) ||
+        throw(ArgumentError("$virtualribosome_id already found in model."))
+
     m = copy(model)
     m.reactions = copy(model.reactions)
     m.reactions[biomass_rxn_id] = copy(model.reactions[biomass_rxn_id])
@@ -580,37 +591,59 @@ function add_virtualribosome(
     m
 end
 
-# Add, change, remove isozymes
+# Add, remove isozymes (no change because the order isozymes may appear in is not constant across models)
 
 """
 $(TYPEDSIGNATURES)
 
-Add `isozymes` to `rxn_id` in `model`.
-"""
-add_isozymes!(model::ObjectModel, rxn_id::String, isozymes::Vector{Isozyme}) =
-    add_isozymes!(model, [rxn_id], [isozymes])
-
-"""
-$(TYPEDSIGNATURES)
-
-For each reaction in `rxn_ids`, add the corresponding isozymes in
-`isozymes_vector` to `model`.
+Plural variant of [`add_isozymes!`](@ref).
 """
 function add_isozymes!(
     model::ObjectModel,
-    rxn_ids::Vector{String},
+    rids::Vector{String},
     isozymes_vector::Vector{Vector{Isozyme}},
 )
-    rxn_ids = keys(model.reactions)
-    idxs = filter(!isnothing, indexin(rxns, rxn_ids))
-    isempty(idxs) ||
-        throw(ArgumentError("Duplicated reaction IDs in model: $(rxn_ids[idxs])"))
-    isnothing(model.reactions[rxn_id].gene_associations) ||
-        throw(ArgumentError("$rxn_id already has isozymes."))
+    throw_argerror_if_key_missing(model, :reactions, rids)
+    throw_argerror_if_isozymes_found(model, rids)
 
-    for (rid, isozymes) in zip(rxn_id_vector, isozymes_vector)
-        add_isozymes!(model, rid, isozymes)
+    for (rid, isozymes) in zip(rids, isozymes_vector)
+        model.reactions[rid].gene_associations = isozymes
     end
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Add `isozymes` to `rid` in `model`. Only allowed if `rid` does not have isozymes assigned to it.
+"""
+add_isozymes!(model::ObjectModel, rid::String, isozymes::Vector{Isozyme}) =
+    add_isozymes!(model, [rid], [isozymes])
+
+"""
+$(TYPEDSIGNATURES)
+
+Plural variant of [`add_isozymes`](@ref).
+"""
+function add_isozymes(
+    model::ObjectModel,
+    rids::Vector{String},
+    isozymes_vector::Vector{Vector{Isozyme}},
+)
+    throw_argerror_if_key_missing(model, :reactions, rids)
+    throw_argerror_if_isozymes_found(model, rids)
+
+    m = copy(model)
+    m.reactions = copy(model.reactions)
+
+    for (rid, isozymes) in zip(rids, isozymes_vector)
+        m.reactions[rid] = copy(model.reactions[rid])
+        if !isnothing(model.reactions[rid].gene_associations)
+            m.reactions[rid].gene_associations =
+                copy(model.reactions[rid].gene_associations)
+        end
+        m.reactions[rid].gene_associations = isozymes
+    end
+    m
 end
 
 """
@@ -619,47 +652,50 @@ $(TYPEDSIGNATURES)
 Variant of [`add_isozymes!`](@ref) that returns a copied model instead of
 modifying the input.
 """
-function add_isozymes(model::ObjectModel, rxn_id::String, isozymes::Vector{Isozyme})
+add_isozymes(model::ObjectModel, rid::String, isozymes::Vector{Isozyme}) =
+    add_isozymes(model, [rid], [isozymes])
 
-    m = copy(model)
-    m.reactions = copy(model.reactions)
+"""
+$(TYPEDSIGNATURES)
 
-    m.reactions[rxn_id] = copy(model.reactions[rxn_id])
-    if !isnothing(model.reactions[rxn_id].gene_associations)
-        m.reactions[rxn_id].gene_associations =
-            copy(model.reactions[rxn_id].gene_associations)
+Plural variant of [`remove_isozyme!`](@ref).
+"""
+function remove_isozymes!(model::ObjectModel, rids::Vector{String})
+    throw_argerror_if_key_missing(model, :reactions, rids)
+    for rid in rids
+        model.reactions[rid].gene_associations = nothing
     end
-    m.reactions[rxn_id].gene_associations = isozymes
-
-    m
 end
 
 """
 $(TYPEDSIGNATURES)
 
-For each pair of `isozymes` and `rxn_id` in `isozymes_vector` and
-`rxn_id_vector`, call [`add_isozymes`](@ref) to add the isozymes to the
-`model`.
+Remove all isozymes from `rid` in `model`.
 """
-function add_isozymes(
-    model::ObjectModel,
-    rxn_id_vector::Vector{String},
-    isozymes_vector::Vector{Vector{Isozyme}},
-)
+remove_isozyme!(model::ObjectModel, rid::String) = remove_isozymes!(model, [rid])
+
+"""
+$(TYPEDSIGNATURES)
+
+Plural variant of [`remove_isozyme`](@ref).
+"""
+function remove_isozymes!(model::ObjectModel, rids::Vector{String})
+    throw_argerror_if_key_missing(model, :reactions, rids)
 
     m = copy(model)
     m.reactions = copy(model.reactions)
-
-    for (rxn_id, isozymes) in zip(rxn_id_vector, isozymes_vector)
-
-        m.reactions[rxn_id] = copy(model.reactions[rxn_id])
-        if !isnothing(model.reactions[rxn_id].gene_associations)
-            m.reactions[rxn_id].gene_associations =
-                copy(model.reactions[rxn_id].gene_associations)
+    for rid in rids
+        m.reactions[rid] = copy(model.reactions[rid])
+        for field in fieldnames(typeof(model.reactions[rid]))
+            setfield!(m.reactions[rid], field, getfield(model.reactions[rid], field))
         end
-        m.reactions[rxn_id].gene_associations = isozymes
-
+        model.reactions[rid].gene_associations = nothing
     end
-
-    m
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Return a shallow copy of `model` with all isozymes of reaction `rid` removed.
+"""
+remove_isozyme(model::ObjectModel, rid::String) = remove_isozymes(model, [rid])

--- a/src/reconstruction/pipes/enzymes.jl
+++ b/src/reconstruction/pipes/enzymes.jl
@@ -1,3 +1,5 @@
+# constructors for enzyme constrained models
+
 """
 $(TYPEDSIGNATURES)
 
@@ -17,20 +19,3 @@ giving a [`EnzymeConstrainedModel`](@ref). The arguments are forwarded to
 """
 with_enzyme_constraints(args...; kwargs...) =
     model -> make_enzyme_constrained_model(model, args...; kwargs...)
-
-"""
-$(TYPEDSIGNATURES)
-
-Specifies a model variant that adds a virtualribosome to a model. Args and kwargs
-are forwarded to [`add_virtualribosome`](@ref).
-"""
-with_virtualribosome(args...; kwargs...) =
-    model -> add_virtualribosome(model, args...; kwargs...)
-
-"""
-$(TYPEDSIGNATURES)
-
-Specifies a model variant that overwrites the current isozymes associated with the
-model through calling [`add_isozymes`](@ref).
-"""
-with_isozymes(args...; kwargs...) = model -> add_isozymes(model, args...; kwargs...)

--- a/src/reconstruction/pipes/generic.jl
+++ b/src/reconstruction/pipes/generic.jl
@@ -103,3 +103,21 @@ Forwards arguments to [`add_biomass_metabolite`](@ref).
 """
 with_added_biomass_metabolite(args...; kwargs...) =
     m -> add_biomass_metabolite(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant with the bounds changed for the gene product. Forwards
+the arguments to [`change_gene_product_bound`](@ref).
+"""
+with_changed_gene_product_bound(args...; kwargs...) =
+    m -> change_gene_product_bound(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Plural version of [`with_changed_gene_product_bound`](@ref), calls
+[`change_gene_product_bounds`](@ref) internally.
+"""
+with_changed_gene_product_bounds(args...; kwargs...) =
+    m -> change_gene_product_bounds(m, args...; kwargs...)

--- a/src/reconstruction/pipes/generic.jl
+++ b/src/reconstruction/pipes/generic.jl
@@ -121,3 +121,11 @@ Plural version of [`with_changed_gene_product_bound`](@ref), calls
 """
 with_changed_gene_product_bounds(args...; kwargs...) =
     m -> change_gene_product_bounds(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant with the objective reaction(s) changed. Forwards the
+arguments to [`change_objective`](@ref).
+"""
+with_changed_objective(args...; kwargs...) = m -> change_objective(m, args...; kwargs...)

--- a/src/reconstruction/pipes/generic.jl
+++ b/src/reconstruction/pipes/generic.jl
@@ -1,3 +1,5 @@
+# Reactions 
+
 """
 $(TYPEDSIGNATURES)
 
@@ -13,6 +15,24 @@ Specifies a model variant with an added reaction. Forwards the arguments to
 [`add_reaction`](@ref).
 """
 with_added_reaction(args...; kwargs...) = m -> add_reaction(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant without a certain reaction. Forwards arguments to
+[`remove_reaction`](@ref).
+"""
+with_removed_reaction(args...; kwargs...) = m -> remove_reaction(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Plural version of [`with_removed_reaction`](@ref), calls
+[`remove_reactions`](@ref) internally.
+"""
+with_removed_reactions(args...; kwargs...) = m -> remove_reactions(m, args...; kwargs...)
+
+# Metabolites
 
 """
 $(TYPEDSIGNATURES)
@@ -33,38 +53,6 @@ with_added_metabolite(args...; kwargs...) = m -> add_metabolite(m, args...; kwar
 """
 $(TYPEDSIGNATURES)
 
-Specifies a model variant with genes added. Forwards the arguments to
-[`add_genes`](@ref).
-"""
-with_added_genes(args...; kwargs...) = m -> add_genes(m, args...; kwargs...)
-
-"""
-$(TYPEDSIGNATURES)
-
-Specifies a model variant with an added gene. Forwards the arguments to
-[`add_gene`](@ref).
-"""
-with_added_gene(args...; kwargs...) = m -> add_gene(m, args...; kwargs...)
-
-"""
-$(TYPEDSIGNATURES)
-
-Specifies a model variant that has a new bound set. Forwards arguments to
-[`change_bound`](@ref). Intended for usage with [`screen`](@ref).
-"""
-with_changed_bound(args...; kwargs...) = m -> change_bound(m, args...; kwargs...)
-
-"""
-$(TYPEDSIGNATURES)
-
-Specifies a model variant that has new bounds set. Forwards arguments to
-[`change_bounds`](@ref). Intended for usage with [`screen`](@ref).
-"""
-with_changed_bounds(args...; kwargs...) = m -> change_bounds(m, args...; kwargs...)
-
-"""
-$(TYPEDSIGNATURES)
-
 Specifies a model variant without a certain metabolite. Forwards arguments to
 [`remove_metabolite`](@ref).
 """
@@ -79,30 +67,61 @@ Plural version of [`with_removed_metabolite`](@ref), calls
 with_removed_metabolites(args...; kwargs...) =
     m -> remove_metabolites(m, args...; kwargs...)
 
-"""
-$(TYPEDSIGNATURES)
-
-Specifies a model variant without a certain reaction. Forwards arguments to
-[`remove_reaction`](@ref).
-"""
-with_removed_reaction(args...; kwargs...) = m -> remove_reaction(m, args...; kwargs...)
+# Genes
 
 """
 $(TYPEDSIGNATURES)
 
-Plural version of [`with_removed_reaction`](@ref), calls
-[`remove_reactions`](@ref) internally.
+Specifies a model variant with genes added. Forwards the arguments to
+[`add_genes`](@ref).
 """
-with_removed_reactions(args...; kwargs...) = m -> remove_reactions(m, args...; kwargs...)
+with_added_genes(args...; kwargs...) = m -> add_genes(m, args...; kwargs...)
 
 """
 $(TYPEDSIGNATURES)
 
-Species a model variant that adds a biomass metabolite to the biomass reaction.
-Forwards arguments to [`add_biomass_metabolite`](@ref).
+Specifies a model variant with an added gene. Forwards the arguments to
+[`add_gene`](@ref).
+"""
+with_added_gene(args...; kwargs...) = m -> add_gene(m, args...; kwargs...)
+
+
+# Biomass
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant that adds a biomass metabolite to the biomass
+reaction. Forwards arguments to [`add_biomass_metabolite`](@ref).
 """
 with_added_biomass_metabolite(args...; kwargs...) =
     m -> add_biomass_metabolite(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant that removes a biomass metabolite from the biomass
+reaction. Forwards arguments to [`remove_biomass_metabolite`](@ref).
+"""
+with_removed_biomass_metabolite(args...; kwargs...) =
+    m -> remove_biomass_metabolite(m, args...; kwargs...)
+
+# Bounds
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant that has a new bound set. Forwards arguments to
+[`change_bound`](@ref). Intended for usage with [`screen`](@ref).
+"""
+with_changed_bound(args...; kwargs...) = m -> change_bound(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Plural variant of [`with_changed_bound`](@ref).
+"""
+with_changed_bounds(args...; kwargs...) = m -> change_bounds(m, args...; kwargs...)
 
 """
 $(TYPEDSIGNATURES)
@@ -121,6 +140,8 @@ Plural version of [`with_changed_gene_product_bound`](@ref), calls
 """
 with_changed_gene_product_bounds(args...; kwargs...) =
     m -> change_gene_product_bounds(m, args...; kwargs...)
+
+# Objective
 
 """
 $(TYPEDSIGNATURES)

--- a/src/reconstruction/pipes/generic.jl
+++ b/src/reconstruction/pipes/generic.jl
@@ -1,4 +1,4 @@
-# Reactions 
+# Reactions
 
 """
 $(TYPEDSIGNATURES)
@@ -86,25 +86,21 @@ Specifies a model variant with an added gene. Forwards the arguments to
 with_added_gene(args...; kwargs...) = m -> add_gene(m, args...; kwargs...)
 
 
-# Biomass
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant with removed genes. Forwards the arguments to
+[`remove_genes`](@ref).
+"""
+with_removed_genes(args...; kwargs...) = m -> remove_genes(m, args...; kwargs...)
 
 """
 $(TYPEDSIGNATURES)
 
-Specifies a model variant that adds a biomass metabolite to the biomass
-reaction. Forwards arguments to [`add_biomass_metabolite`](@ref).
+Specifies a model variant with a gene removed. Forwards the arguments to
+[`remove_gene`](@ref).
 """
-with_added_biomass_metabolite(args...; kwargs...) =
-    m -> add_biomass_metabolite(m, args...; kwargs...)
-
-"""
-$(TYPEDSIGNATURES)
-
-Specifies a model variant that removes a biomass metabolite from the biomass
-reaction. Forwards arguments to [`remove_biomass_metabolite`](@ref).
-"""
-with_removed_biomass_metabolite(args...; kwargs...) =
-    m -> remove_biomass_metabolite(m, args...; kwargs...)
+with_removed_gene(args...; kwargs...) = m -> remove_gene(m, args...; kwargs...)
 
 # Bounds
 
@@ -150,3 +146,53 @@ Specifies a model variant with the objective reaction(s) changed. Forwards the
 arguments to [`change_objective`](@ref).
 """
 with_changed_objective(args...; kwargs...) = m -> change_objective(m, args...; kwargs...)
+
+# Biomass
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant that adds a biomass metabolite to the biomass
+reaction. Forwards arguments to [`add_biomass_metabolite`](@ref).
+"""
+with_added_biomass_metabolite(args...; kwargs...) =
+    m -> add_biomass_metabolite(m, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant that removes a biomass metabolite from the biomass
+reaction. Forwards arguments to [`remove_biomass_metabolite`](@ref).
+"""
+with_removed_biomass_metabolite(args...; kwargs...) =
+    m -> remove_biomass_metabolite(m, args...; kwargs...)
+
+# Virtual ribosome
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant that adds a virtualribosome to a model. Args and kwargs
+are forwarded to [`add_virtualribosome`](@ref).
+"""
+with_virtualribosome(args...; kwargs...) =
+    model -> add_virtualribosome(model, args...; kwargs...)
+
+# Isozymes
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant that adds isozymes to the model through calling
+[`add_isozyme`](@ref).
+"""
+with_added_isozymes(args...; kwargs...) = model -> add_isozymes(model, args...; kwargs...)
+
+"""
+$(TYPEDSIGNATURES)
+
+Specifies a model variant that removes isozymes to the model through calling
+[`remove_isozymes`](@ref).
+"""
+with_removed_isozymes(args...; kwargs...) =
+    model -> remove_isozymes(model, args...; kwargs...)

--- a/test/analysis/flux_balance_analysis.jl
+++ b/test/analysis/flux_balance_analysis.jl
@@ -75,13 +75,15 @@ end
     @test_throws DomainError flux_balance_analysis(
         model,
         Tulip.Optimizer;
-        modifications = [modify_objective("gbbrsh"; lower_bound = -12, upper_bound = -12)],
+        modifications = [modify_constraint("gbbrsh"; lower_bound = -12, upper_bound = -12)],
     ) |> values_dict
+
     @test_throws DomainError flux_balance_analysis(
         model,
         Tulip.Optimizer;
         modifications = [modify_objective("gbbrsh")],
     ) |> values_dict
+
     @test_throws DomainError flux_balance_analysis(
         model,
         Tulip.Optimizer;

--- a/test/analysis/flux_balance_analysis.jl
+++ b/test/analysis/flux_balance_analysis.jl
@@ -39,10 +39,10 @@ end
             model,
             Tulip.Optimizer;
             modifications = [
-                change_objective("BIOMASS_Ecoli_core_w_GAM"),
-                change_constraint("EX_glc__D_e"; lower_bound = -12, upper_bound = -12),
-                change_sense(MAX_SENSE),
-                change_optimizer_attribute("IPM_IterationsLimit", 110),
+                modify_objective("BIOMASS_Ecoli_core_w_GAM"),
+                modify_constraint("EX_glc__D_e"; lower_bound = -12, upper_bound = -12),
+                modify_sense(MAX_SENSE),
+                modify_optimizer_attribute("IPM_IterationsLimit", 110),
             ],
         ) |> values_dict
 
@@ -59,7 +59,7 @@ end
             model,
             Tulip.Optimizer;
             modifications = [
-                change_objective(
+                modify_objective(
                     ["BIOMASS_Ecoli_core_w_GAM", "PFL"];
                     weights = [biomass_frac, pfl_frac],
                 ),
@@ -75,17 +75,17 @@ end
     @test_throws DomainError flux_balance_analysis(
         model,
         Tulip.Optimizer;
-        modifications = [change_constraint("gbbrsh"; lower_bound = -12, upper_bound = -12)],
+        modifications = [modify_objective("gbbrsh"; lower_bound = -12, upper_bound = -12)],
     ) |> values_dict
     @test_throws DomainError flux_balance_analysis(
         model,
         Tulip.Optimizer;
-        modifications = [change_objective("gbbrsh")],
+        modifications = [modify_objective("gbbrsh")],
     ) |> values_dict
     @test_throws DomainError flux_balance_analysis(
         model,
         Tulip.Optimizer;
-        modifications = [change_objective(["BIOMASS_Ecoli_core_w_GAM"; "gbbrsh"])],
+        modifications = [modify_objective(["BIOMASS_Ecoli_core_w_GAM"; "gbbrsh"])],
     )
 end
 

--- a/test/analysis/knockouts.jl
+++ b/test/analysis/knockouts.jl
@@ -120,10 +120,10 @@ end
                 model,
                 Tulip.Optimizer;
                 modifications = [
-                    change_objective("BIOMASS_Ecoli_core_w_GAM"),
-                    change_constraint("EX_glc__D_e"; lower_bound = -12, upper_bound = -12),
-                    change_sense(MAX_SENSE),
-                    change_optimizer_attribute("IPM_IterationsLimit", 110),
+                    modify_objective("BIOMASS_Ecoli_core_w_GAM"),
+                    modify_constraint("EX_glc__D_e"; lower_bound = -12, upper_bound = -12),
+                    modify_sense(MAX_SENSE),
+                    modify_optimizer_attribute("IPM_IterationsLimit", 110),
                     knockout(["b0978", "b0734"]), # knockouts out cytbd
                 ],
             ) |> values_dict
@@ -138,10 +138,10 @@ end
                 model,
                 Tulip.Optimizer;
                 modifications = [
-                    change_objective("BIOMASS_Ecoli_core_w_GAM"),
-                    change_constraint("EX_glc__D_e"; lower_bound = -12, upper_bound = -12),
-                    change_sense(MAX_SENSE),
-                    change_optimizer_attribute("IPM_IterationsLimit", 110),
+                    modify_objective("BIOMASS_Ecoli_core_w_GAM"),
+                    modify_constraint("EX_glc__D_e"; lower_bound = -12, upper_bound = -12),
+                    modify_sense(MAX_SENSE),
+                    modify_optimizer_attribute("IPM_IterationsLimit", 110),
                     knockout("b2779"), # knockouts out enolase
                 ],
             ) |> values_dict

--- a/test/analysis/max_min_driving_force.jl
+++ b/test/analysis/max_min_driving_force.jl
@@ -28,7 +28,7 @@
     x = flux_balance_analysis(
         mmdfm,
         Tulip.Optimizer;
-        modifications = [change_optimizer_attribute("IPM_IterationsLimit", 1000)],
+        modifications = [modify_optimizer_attribute("IPM_IterationsLimit", 1000)],
     )
 
     # get mmdf
@@ -44,7 +44,7 @@
             mmdfm,
             Tulip.Optimizer;
             bounds = gamma_bounds(0.9),
-            modifications = [change_optimizer_attribute("IPM_IterationsLimit", 1000)],
+            modifications = [modify_optimizer_attribute("IPM_IterationsLimit", 1000)],
         ) |> result
 
     pyk_idx = first(indexin(["ΔG PYK"], gibbs_free_energy_reactions(mmdfm)))

--- a/test/analysis/parsimonious_flux_balance_analysis.jl
+++ b/test/analysis/parsimonious_flux_balance_analysis.jl
@@ -9,7 +9,7 @@
                 modify_constraint("EX_m1(e)", lower_bound = -10.0),
                 modify_optimizer_attribute("IPM_IterationsLimit", 500),
             ],
-            qp_modifications = [change_optimizer(Clarabel.Optimizer), silence],
+            qp_modifications = [modify_optimizer(Clarabel.Optimizer), silence],
         ) |> values_dict
 
     # The used optimizer doesn't really converge to the same answer everytime

--- a/test/analysis/parsimonious_flux_balance_analysis.jl
+++ b/test/analysis/parsimonious_flux_balance_analysis.jl
@@ -6,8 +6,8 @@
             model,
             Tulip.Optimizer;
             modifications = [
-                change_constraint("EX_m1(e)", lower_bound = -10.0),
-                change_optimizer_attribute("IPM_IterationsLimit", 500),
+                modify_constraint("EX_m1(e)", lower_bound = -10.0),
+                modify_optimizer_attribute("IPM_IterationsLimit", 500),
             ],
             qp_modifications = [change_optimizer(Clarabel.Optimizer), silence],
         ) |> values_dict

--- a/test/analysis/screening.jl
+++ b/test/analysis/screening.jl
@@ -53,7 +53,7 @@
             Analysis.flux_balance_analysis(
                 m,
                 Tulip.Optimizer;
-                modifications = [change_sense(sense)],
+                modifications = [modify_sense(sense)],
             ) |> COBREXA.Solver.values_vec,
         args = [(MIN_SENSE,), (MAX_SENSE,)],
     ) == [

--- a/test/analysis/variability_analysis.jl
+++ b/test/analysis/variability_analysis.jl
@@ -101,9 +101,9 @@ end
             Tulip.Optimizer;
             bounds = objective_bounds(0.99),
             modifications = [
-                change_optimizer_attribute("IPM_IterationsLimit", 500),
-                change_constraint("EX_glc__D_e"; lower_bound = -10, upper_bound = -10),
-                change_constraint("EX_o2_e"; lower_bound = 0.0, upper_bound = 0.0),
+                modify_optimizer_attribute("IPM_IterationsLimit", 500),
+                modify_constraint("EX_glc__D_e"; lower_bound = -10, upper_bound = -10),
+                modify_constraint("EX_o2_e"; lower_bound = 0.0, upper_bound = 0.0),
             ],
         ) |> result
 

--- a/test/reconstruction/ObjectModel.jl
+++ b/test/reconstruction/ObjectModel.jl
@@ -104,6 +104,8 @@
     remove_reaction!(model, "r1")
     @test length(model.reactions) == 2
 
+    @test_throws ArgumentError add_reaction!(model, r3)
+
     ### metabolites
     add_metabolites!(model, [m5, m6])
     @test length(model.metabolites) == 6
@@ -116,6 +118,8 @@
 
     remove_metabolite!(model, "m1")
     @test length(model.metabolites) == 4
+
+    @test_throws ArgumentError add_metabolite!(model, m2) 
 
     ### genes
     add_genes!(model, [g5, g6])
@@ -130,6 +134,8 @@
     remove_gene!(model, "g1")
     @test length(model.genes) == 4
 
+    @test_throws ArgumentError add_gene!(model, g7) 
+    
     # change gene
     change_gene_product_bound!(model, "g1"; lower_bound = -10, upper_bound = 10)
     @test model.genes["g1"].product_lower_bound == -10.0

--- a/test/reconstruction/ObjectModel.jl
+++ b/test/reconstruction/ObjectModel.jl
@@ -105,6 +105,7 @@
     @test length(model.reactions) == 2
 
     @test_throws ArgumentError add_reaction!(model, r3)
+    @test_throws ArgumentError remove_reaction!(model, "abc")
 
     ### metabolites
     add_metabolites!(model, [m5, m6])
@@ -120,6 +121,7 @@
     @test length(model.metabolites) == 4
 
     @test_throws ArgumentError add_metabolite!(model, m2) 
+    @test_throws ArgumentError remove_metabolite!(model, "abc") 
 
     ### genes
     add_genes!(model, [g5, g6])
@@ -134,12 +136,13 @@
     remove_gene!(model, "g1")
     @test length(model.genes) == 4
 
-    @test_throws ArgumentError add_gene!(model, g7) 
+    @test_throws ArgumentError add_gene!(model, g7)
+    @test_throws ArgumentError remove_gene!(model, "abc")
     
     # change gene
-    change_gene_product_bound!(model, "g1"; lower_bound = -10, upper_bound = 10)
-    @test model.genes["g1"].product_lower_bound == -10.0
-    @test model.genes["g1"].product_upper_bound == 10.0
+    change_gene_product_bound!(model, "g3"; lower_bound = -10, upper_bound = 10)
+    @test model.genes["g3"].product_lower_bound == -10.0
+    @test model.genes["g3"].product_upper_bound == 10.0
 
     new_model = change_gene_product_bound(model, "g2"; lower_bound = -10, upper_bound = 10)
     @test new_model.genes["g2"].product_lower_bound == -10.0

--- a/test/reconstruction/ObjectModel.jl
+++ b/test/reconstruction/ObjectModel.jl
@@ -147,4 +147,5 @@
     new_model = change_gene_product_bound(model, "g2"; lower_bound = -10, upper_bound = 10)
     @test new_model.genes["g2"].product_lower_bound == -10.0
     @test new_model.genes["g2"].product_upper_bound == 10.0
+    @test model.genes["g2"].product_lower_bound == 0.0
 end

--- a/test/reconstruction/ObjectModel.jl
+++ b/test/reconstruction/ObjectModel.jl
@@ -7,6 +7,7 @@
     m5 = Metabolite("m5")
     m6 = Metabolite("m6")
     m7 = Metabolite("m7")
+    mtest = Metabolite("mtest")
 
     g1 = Gene("g1")
     g2 = Gene("g2")
@@ -16,6 +17,7 @@
     g5 = Gene("g5")
     g6 = Gene("g6")
     g7 = Gene("g7")
+    gtest = Gene("gtest")
 
     r1 = ReactionForward("r1", Dict(m1.id => -1.0, m2.id => 1.0))
     r2 = ReactionBidirectional("r2", Dict(m2.id => -2.0, m3.id => 1.0))
@@ -23,6 +25,7 @@
     r3 = ReactionBackward("r3", Dict(m1.id => -1.0, m4.id => 2.0))
     r4 = ReactionBackward("r4", Dict(m1.id => -5.0, m4.id => 2.0))
     r5 = ReactionBackward("r5", Dict(m1.id => -11.0, m4.id => 2.0, m3.id => 2.0))
+    rtest = ReactionForward("rtest", Dict(m1.id => -1.0, m2.id => 1.0))
 
     rxns = [r1, r2]
 
@@ -104,6 +107,14 @@
     remove_reaction!(model, "r1")
     @test length(model.reactions) == 2
 
+    new_model = model |> with_added_reaction(rtest)
+    @test haskey(new_model.reactions, "rtest")
+    @test !haskey(model.reactions, "rtest")
+
+    new_model2 = new_model |> with_removed_reaction("rtest")
+    @test !haskey(new_model2.reactions, "rtest")
+    @test haskey(new_model.reactions, "rtest")
+
     @test_throws ArgumentError add_reaction!(model, r3)
     @test_throws ArgumentError remove_reaction!(model, "abc")
 
@@ -119,6 +130,14 @@
 
     remove_metabolite!(model, "m1")
     @test length(model.metabolites) == 4
+
+    new_model = model |> with_added_metabolite(mtest)
+    @test haskey(new_model.metabolites, "mtest")
+    @test !haskey(model.metabolites, "mtest")
+
+    new_model2 = new_model |> with_removed_metabolite("mtest")
+    @test !haskey(new_model2.metabolites, "mtest")
+    @test haskey(new_model.metabolites, "mtest")
 
     @test_throws ArgumentError add_metabolite!(model, m2)
     @test_throws ArgumentError remove_metabolite!(model, "abc")
@@ -136,6 +155,14 @@
     remove_gene!(model, "g1")
     @test length(model.genes) == 4
 
+    new_model = model |> with_added_gene(gtest)
+    @test haskey(new_model.genes, "gtest")
+    @test !haskey(model.genes, "gtest")
+
+    new_model2 = new_model |> with_removed_gene("gtest")
+    @test !haskey(new_model2.genes, "gtest")
+    @test haskey(new_model.genes, "gtest")
+
     @test_throws ArgumentError add_gene!(model, g7)
     @test_throws ArgumentError remove_gene!(model, "abc")
 
@@ -148,4 +175,14 @@
     @test new_model.genes["g2"].product_lower_bound == -10.0
     @test new_model.genes["g2"].product_upper_bound == 10.0
     @test model.genes["g2"].product_lower_bound == 0.0
+
+    # isozymes
+    isos = [Isozyme(["g1"])]
+    new_model = model |> with_removed_isozymes("r2")
+    @test isnothing(new_model.reactions["r2"].gene_associations)
+    @test !isnothing(model.reactions["r2"].gene_associations)
+
+    new_model2 = new_model |> with_added_isozymes("r2", isos)
+    @test !isnothing(new_model2.reactions["r2"].gene_associations)
+    @test isnothing(new_model.reactions["r2"].gene_associations)
 end

--- a/test/reconstruction/ObjectModel.jl
+++ b/test/reconstruction/ObjectModel.jl
@@ -120,8 +120,8 @@
     remove_metabolite!(model, "m1")
     @test length(model.metabolites) == 4
 
-    @test_throws ArgumentError add_metabolite!(model, m2) 
-    @test_throws ArgumentError remove_metabolite!(model, "abc") 
+    @test_throws ArgumentError add_metabolite!(model, m2)
+    @test_throws ArgumentError remove_metabolite!(model, "abc")
 
     ### genes
     add_genes!(model, [g5, g6])
@@ -138,7 +138,7 @@
 
     @test_throws ArgumentError add_gene!(model, g7)
     @test_throws ArgumentError remove_gene!(model, "abc")
-    
+
     # change gene
     change_gene_product_bound!(model, "g3"; lower_bound = -10, upper_bound = 10)
     @test model.genes["g3"].product_lower_bound == -10.0

--- a/test/reconstruction/ObjectModel.jl
+++ b/test/reconstruction/ObjectModel.jl
@@ -84,6 +84,13 @@
     @test new_model.reactions["r2"].lower_bound == -220
     @test new_model.reactions["r2"].upper_bound == 20
 
+    ### objective
+    change_objective!(model, "r2")
+    @test model.objective["r2"] == 1.0
+
+    new_model = change_objective(model, "r1"; weight = 2.0)
+    @test new_model.objective["r1"] == 2.0
+
     ### reactions
     add_reactions!(model, [r3, r4])
     @test length(model.reactions) == 4
@@ -123,7 +130,12 @@
     remove_gene!(model, "g1")
     @test length(model.genes) == 4
 
-    ### objective
-    change_objective!(model, "r2")
-    @test model.objective["r2"] == 1.0
+    # change gene
+    change_gene_product_bound!(model, "g1"; lower_bound = -10, upper_bound = 10)
+    @test model.genes["g1"].product_lower_bound == -10.0
+    @test model.genes["g1"].product_upper_bound == 10.0
+
+    new_model = change_gene_product_bound(model, "g2"; lower_bound = -10, upper_bound = 10)
+    @test new_model.genes["g2"].product_lower_bound == -10.0
+    @test new_model.genes["g2"].product_upper_bound == 10.0
 end

--- a/test/reconstruction/ObjectModel.jl
+++ b/test/reconstruction/ObjectModel.jl
@@ -115,8 +115,8 @@
     @test !haskey(new_model2.reactions, "rtest")
     @test haskey(new_model.reactions, "rtest")
 
-    @test_throws ArgumentError add_reaction!(model, r3)
-    @test_throws ArgumentError remove_reaction!(model, "abc")
+    @test_throws DomainError add_reaction!(model, r3)
+    @test_throws DomainError remove_reaction!(model, "abc")
 
     ### metabolites
     add_metabolites!(model, [m5, m6])
@@ -139,8 +139,8 @@
     @test !haskey(new_model2.metabolites, "mtest")
     @test haskey(new_model.metabolites, "mtest")
 
-    @test_throws ArgumentError add_metabolite!(model, m2)
-    @test_throws ArgumentError remove_metabolite!(model, "abc")
+    @test_throws DomainError add_metabolite!(model, m2)
+    @test_throws DomainError remove_metabolite!(model, "abc")
 
     ### genes
     add_genes!(model, [g5, g6])
@@ -163,8 +163,8 @@
     @test !haskey(new_model2.genes, "gtest")
     @test haskey(new_model.genes, "gtest")
 
-    @test_throws ArgumentError add_gene!(model, g7)
-    @test_throws ArgumentError remove_gene!(model, "abc")
+    @test_throws DomainError add_gene!(model, g7)
+    @test_throws DomainError remove_gene!(model, "abc")
 
     # change gene
     change_gene_product_bound!(model, "g3"; lower_bound = -10, upper_bound = 10)

--- a/test/reconstruction/constrained_allocation.jl
+++ b/test/reconstruction/constrained_allocation.jl
@@ -46,7 +46,7 @@
 
     add_metabolites!(m, [Metabolite("m$i") for i = 1:4])
 
-    @test_throws ArgumentError (m |> with_virtualribosome("r6", 0.2))
+    @test_throws DomainError (m |> with_virtualribosome("r6", 0.2))
 
     ribomodel = m |> with_removed_isozymes("r6") |> with_virtualribosome("r6", 0.2)
 

--- a/test/reconstruction/constrained_allocation.jl
+++ b/test/reconstruction/constrained_allocation.jl
@@ -46,12 +46,13 @@
 
     add_metabolites!(m, [Metabolite("m$i") for i = 1:4])
 
-    ribomodel = m |> with_virtualribosome("r6", 0.2)
+    @test_throws ArgumentError (m |> with_virtualribosome("r6", 0.2))
+
+    ribomodel = m |> with_removed_isozymes("r6") |> with_virtualribosome("r6", 0.2)
 
     @test haskey(ribomodel.genes, "virtualribosome")
     @test first(ribomodel.reactions["r6"].gene_associations).kcat_forward == 0.2
     @test first(m.reactions["r6"].gene_associations).kcat_forward == 10.0
-
 
     cam = make_simplified_enzyme_constrained_model(
         ribomodel;
@@ -69,6 +70,7 @@
     @test isapprox(rxn_fluxes["r6"], 0.09695290851008717, atol = TEST_TOLERANCE)
 
     # test inplace variant
+    remove_isozymes!(m, "r6")
     add_virtualribosome!(m, "r6", 0.2)
     cam = m |> with_simplified_enzyme_constraints(total_gene_product_mass_bound = 0.5)
 
@@ -81,21 +83,4 @@
             modifications = [modify_optimizer_attribute("IPM_IterationsLimit", 1000)],
         ) |> values_dict(:reaction)
     @test isapprox(rxn_fluxes["r6"], 0.09695290851008717, atol = TEST_TOLERANCE)
-
-    # test with_isozyme functions
-    iso1 = Isozyme(["g1"]; kcat_forward = 200.0, kcat_backward = 300.0)
-    iso2 = Isozyme(["g2"]; kcat_forward = 100.0, kcat_backward = 500.0)
-    m2 = m |> with_isozymes(["r3", "r4"], [[iso1], [iso2]])
-    @test first(m2.reactions["r3"].gene_associations).kcat_backward == 300.0
-    @test first(m2.reactions["r4"].gene_associations).kcat_backward == 500.0
-    @test first(m.reactions["r3"].gene_associations).kcat_backward == 1.0
-
-    m2 = m |> with_isozymes("r3", [iso2])
-    @test first(m2.reactions["r3"].gene_associations).kcat_backward == 500.0
-    @test first(m.reactions["r3"].gene_associations).kcat_backward == 1.0
-
-    add_isozymes!(m, ["r3", "r4"], [[iso1], [iso2]])
-    @test first(m.reactions["r3"].gene_associations).kcat_backward == 300.0
-    @test first(m.reactions["r4"].gene_associations).kcat_backward == 500.0
-
 end

--- a/test/reconstruction/constrained_allocation.jl
+++ b/test/reconstruction/constrained_allocation.jl
@@ -64,7 +64,7 @@
         flux_balance_analysis(
             cam,
             Tulip.Optimizer;
-            modifications = [change_optimizer_attribute("IPM_IterationsLimit", 1000)],
+            modifications = [modify_optimizer_attribute("IPM_IterationsLimit", 1000)],
         ) |> values_dict(:reaction)
     @test isapprox(rxn_fluxes["r6"], 0.09695290851008717, atol = TEST_TOLERANCE)
 
@@ -78,7 +78,7 @@
         flux_balance_analysis(
             cam,
             Tulip.Optimizer;
-            modifications = [change_optimizer_attribute("IPM_IterationsLimit", 1000)],
+            modifications = [modify_optimizer_attribute("IPM_IterationsLimit", 1000)],
         ) |> values_dict(:reaction)
     @test isapprox(rxn_fluxes["r6"], 0.09695290851008717, atol = TEST_TOLERANCE)
 

--- a/test/reconstruction/enzyme_constrained.jl
+++ b/test/reconstruction/enzyme_constrained.jl
@@ -48,7 +48,7 @@
     res = flux_balance_analysis(
         gm,
         Tulip.Optimizer;
-        modifications = [change_optimizer_attribute("IPM_IterationsLimit", 1000)],
+        modifications = [modify_optimizer_attribute("IPM_IterationsLimit", 1000)],
     )
 
     rxn_fluxes = values_dict(:reaction, res)
@@ -79,9 +79,9 @@
         gm,
         Tulip.Optimizer;
         modifications = [
-            change_objective(genes(gm); weights = [], sense = MIN_SENSE),
-            change_constraint("BIOMASS_Ecoli_core_w_GAM", lower_bound = growth_lb),
-            change_optimizer_attribute("IPM_IterationsLimit", 1000),
+            modify_objective(genes(gm); weights = [], sense = MIN_SENSE),
+            modify_constraint("BIOMASS_Ecoli_core_w_GAM", lower_bound = growth_lb),
+            modify_optimizer_attribute("IPM_IterationsLimit", 1000),
         ],
     )
     mass_groups_min = values_dict(:enzyme_group, res)
@@ -146,7 +146,7 @@ end
     res = flux_balance_analysis(
         gm,
         Tulip.Optimizer;
-        modifications = [change_optimizer_attribute("IPM_IterationsLimit", 1000)],
+        modifications = [modify_optimizer_attribute("IPM_IterationsLimit", 1000)],
     )
 
     rxn_fluxes = values_dict(:reaction, res)

--- a/test/reconstruction/simplified_enzyme_constrained.jl
+++ b/test/reconstruction/simplified_enzyme_constrained.jl
@@ -40,7 +40,7 @@
         flux_balance_analysis(
             simplified_enzyme_constrained_model,
             Tulip.Optimizer;
-            modifications = [change_optimizer_attribute("IPM_IterationsLimit", 1000)],
+            modifications = [modify_optimizer_attribute("IPM_IterationsLimit", 1000)],
         ) |> values_dict
 
     @test isapprox(

--- a/test/types/BalancedGrowthCommunityModel.jl
+++ b/test/types/BalancedGrowthCommunityModel.jl
@@ -335,7 +335,7 @@ end
     res = flux_balance_analysis(
         cm,
         Tulip.Optimizer;
-        modifications = [change_optimizer_attribute("IPM_IterationsLimit", 1000)],
+        modifications = [modify_optimizer_attribute("IPM_IterationsLimit", 1000)],
     )
 
     f_d = values_dict(:reaction, res)

--- a/test/types/FluxSummary.jl
+++ b/test/types/FluxSummary.jl
@@ -5,7 +5,7 @@
         flux_balance_analysis(
             model,
             Tulip.Optimizer;
-            modifications = [change_optimizer_attribute("IPM_IterationsLimit", 200)],
+            modifications = [modify_optimizer_attribute("IPM_IterationsLimit", 200)],
         ) |> values_dict
 
     fr = flux_summary(sol; keep_unbounded = true, large_flux_bound = 25)

--- a/test/types/FluxVariabilitySummary.jl
+++ b/test/types/FluxVariabilitySummary.jl
@@ -6,7 +6,7 @@
             model,
             Tulip.Optimizer;
             bounds = objective_bounds(0.90),
-            modifications = [change_optimizer_attribute("IPM_IterationsLimit", 2000)],
+            modifications = [modify_optimizer_attribute("IPM_IterationsLimit", 2000)],
         ) |> result
 
     fr = flux_variability_summary(sol)

--- a/test/utils/ObjectModel.jl
+++ b/test/utils/ObjectModel.jl
@@ -6,7 +6,7 @@
         flux_balance_analysis(
             model,
             Tulip.Optimizer;
-            modifications = [change_objective("BIOMASS_Ecoli_core_w_GAM")],
+            modifications = [modify_objective("BIOMASS_Ecoli_core_w_GAM")],
         ) |> values_dict
 
     # bounds setting # TODO why is this here?

--- a/test/utils/fluxes.jl
+++ b/test/utils/fluxes.jl
@@ -5,7 +5,7 @@
         flux_balance_analysis(
             model,
             Tulip.Optimizer;
-            modifications = [change_objective("BIOMASS_Ecoli_core_w_GAM")],
+            modifications = [modify_objective("BIOMASS_Ecoli_core_w_GAM")],
         ) |> values_dict
 
     consuming, producing = metabolite_fluxes(model, fluxes)

--- a/test/utils/reaction.jl
+++ b/test/utils/reaction.jl
@@ -6,7 +6,7 @@
         flux_balance_analysis(
             model,
             Tulip.Optimizer;
-            modifications = [change_objective("BIOMASS_Ecoli_core_w_GAM")],
+            modifications = [modify_objective("BIOMASS_Ecoli_core_w_GAM")],
         ) |> values_dict
 
     # test if reaction is balanced


### PR DESCRIPTION
adds non-inplace `change_objective` as well as pipe
fixes `change_bound` to copy all fields
adds `change_gene_product_bound` in-place, non-inplace, as well as pipes
Also change modifications to have the prefix `modify_` instead of `change`. This was to prevent name space issues.

Reconstruction functions have `add_`, `remove_` and `change_` prefixes now. 