### PR TITLE
make the semantics cut

### DIFF
--- a/docs/src/concepts/3_custom_models.md
+++ b/docs/src/concepts/3_custom_models.md
@@ -50,10 +50,10 @@ First, define the reactions and metabolites:
 
 ```julia
 COBREXA.reaction_count(m::CircularModel) = m.size
-COBREXA.n_metabolites(m::CircularModel) = m.size
+COBREXA.metabolite_count(m::CircularModel) = m.size
 
 COBREXA.reaction_ids(m::CircularModel) = ["rxn$i" for i in 1:reaction_count(m)]
-COBREXA.metabolites(m::CircularModel) = ["met$i" for i in 1:n_metabolites(m)]
+COBREXA.metabolite_ids(m::CircularModel) = ["met$i" for i in 1:metabolite_count(m)]
 ```
 
 It is useful to re-use the already defined functions, as that improves the code

--- a/docs/src/concepts/4_wrappers.md
+++ b/docs/src/concepts/4_wrappers.md
@@ -108,7 +108,7 @@ modifying the reaction list, stoichiometry, and bounds:
 COBREXA.unwrap_model(x::LeakyModel) = x.mdl
 COBREXA.reaction_count(x::LeakyModel) = reaction_count(x.mdl) + 1
 COBREXA.reaction_ids(x::LeakyModel) = [reaction_ids(x.mdl); "The Leak"]
-COBREXA.stoichiometry(x::LeakyModel) = [stoichiometry(x.mdl) [m in x.leaking_metabolites ? -1.0 : 0.0 for m = metabolites(x.mdl)]]
+COBREXA.stoichiometry(x::LeakyModel) = [stoichiometry(x.mdl) [m in x.leaking_metabolites ? -1.0 : 0.0 for m = metabolite_ids(x.mdl)]]
 function COBREXA.variable_bounds(x::LeakyModel)
     (l, u) = variable_bounds(x.mdl)
     return ([l; x.leak_rate], [u; x.leak_rate])

--- a/docs/src/examples/02_convert_save.jl
+++ b/docs/src/examples/02_convert_save.jl
@@ -41,7 +41,7 @@ open(f -> serialize(f, sm), "myModel.stdmodel", "w")
 # The models can then be loaded back using `deserialize`:
 
 sm2 = deserialize("myModel.stdmodel")
-issetequal(metabolites(sm), metabolites(sm2))
+issetequal(metabolite_ids(sm), metabolite_ids(sm2))
 
 # This form of loading operation is usually pretty quick:
 t = @elapsed deserialize("myModel.stdmodel")

--- a/docs/src/examples/04_standardmodel.jl
+++ b/docs/src/examples/04_standardmodel.jl
@@ -76,7 +76,7 @@ model.genes[random_gene_id]
 # The same idea holds for both metabolites (stored as `Metabolite`s) and
 # reactions (stored as `Reaction`s). This is demonstrated below.
 
-random_metabolite_id = metabolites(model)[rand(1:n_metabolites(model))]
+random_metabolite_id = metabolite_ids(model)[rand(1:metabolite_count(model))]
 model.metabolites[random_metabolite_id]
 #
 random_reaction_id = variable_ids(model)[rand(1:variable_count(model))]

--- a/src/analysis/modifications/community.jl
+++ b/src/analysis/modifications/community.jl
@@ -29,7 +29,7 @@ modify_abundances(new_abundances::Vector{Float64}) =
 
         n_vars = variable_count(model)
         n_env_vars = length(model.environmental_links)
-        n_cons = length(opt_model[:mb])
+        n_cons = length(opt_model[:metabolite_eqs])
         n_objs = model isa CommunityModel ? 0 : length(model.inner.members)
 
         row_offset =
@@ -38,7 +38,7 @@ modify_abundances(new_abundances::Vector{Float64}) =
         # fix abundance coefficients of species exchanges
         for (i, j, v) in zip(findnz(env_rows)...)
             ii = i + row_offset
-            set_normalized_coefficient(opt_model[:mb][ii], opt_model[:x][j], v)
+            set_normalized_coefficient(opt_model[:metabolite_eqs][ii], opt_model[:x][j], v)
         end
 
         column_offset =
@@ -48,6 +48,6 @@ modify_abundances(new_abundances::Vector{Float64}) =
         for (i, j, v) in zip(findnz(env_link)...)
             jj = j + column_offset
             ii = i + row_offset
-            set_normalized_coefficient(opt_model[:mb][ii], opt_model[:x][jj], -v)
+            set_normalized_coefficient(opt_model[:metabolite_eqs][ii], opt_model[:x][jj], -v)
         end
     end

--- a/src/analysis/modifications/community.jl
+++ b/src/analysis/modifications/community.jl
@@ -48,6 +48,10 @@ modify_abundances(new_abundances::Vector{Float64}) =
         for (i, j, v) in zip(findnz(env_link)...)
             jj = j + column_offset
             ii = i + row_offset
-            set_normalized_coefficient(opt_model[:metabolite_eqs][ii], opt_model[:x][jj], -v)
+            set_normalized_coefficient(
+                opt_model[:metabolite_eqs][ii],
+                opt_model[:x][jj],
+                -v,
+            )
         end
     end

--- a/src/analysis/reconstruction/gapfill_minimum_reactions.jl
+++ b/src/analysis/reconstruction/gapfill_minimum_reactions.jl
@@ -54,7 +54,7 @@ function gapfill_minimum_reactions(
     precache!(model)
 
     # constraints from universal reactions that can fill gaps
-    univs = _universal_stoichiometry(universal_reactions, metabolites(model))
+    univs = _universal_stoichiometry(universal_reactions, metabolite_ids(model))
 
     # add space for additional metabolites and glue with the universal reaction
     # stoichiometry
@@ -89,7 +89,7 @@ function gapfill_minimum_reactions(
     @constraint(
         opt_model,
         extended_stoichiometry * [x; ux] .==
-        [balance(model); zeros(length(univs.new_mids))]
+        [metabolite_bounds(model); zeros(length(univs.new_mids))]
     )
 
     # objective bounds

--- a/src/analysis/sampling/affine_hit_and_run.jl
+++ b/src/analysis/sampling/affine_hit_and_run.jl
@@ -27,7 +27,7 @@ warmup_points = warmup_from_variability(model, GLPK.Optimizer)
 samples = affine_hit_and_run(model, warmup_points, sample_iters = 101:105)
 
 # convert the result to flux (for models where the distinction matters):
-fluxes = reaction_variables_matrix(model)' * samples
+fluxes = reaction_variables_matrix(model) * samples
 ```
 """
 function affine_hit_and_run(

--- a/src/analysis/variability_analysis.jl
+++ b/src/analysis/variability_analysis.jl
@@ -77,7 +77,7 @@ function variability_analysis(
     variability_analysis(
         model,
         optimizer;
-        directions = s.mapping_matrix(model)[:, indexes],
+        directions = (s.mapping_matrix(model)')[:, indexes],
         kwargs...,
     )
 end

--- a/src/io/h5.jl
+++ b/src/io/h5.jl
@@ -23,12 +23,12 @@ make new HDF5 models.
 function save_h5_model(model::AbstractMetabolicModel, file_name::String)::HDF5Model
     rxns = variable_ids(model)
     rxnp = sortperm(rxns)
-    mets = metabolites(model)
+    mets = metabolite_ids(model)
     metp = sortperm(mets)
     h5open(file_name, "w") do f
         write(f, "metabolites", mets[metp])
         write(f, "reactions", rxns[rxnp])
-        h5_write_sparse(create_group(f, "balance"), balance(model)[metp])
+        h5_write_sparse(create_group(f, "balance"), metabolite_bounds(model)[metp])
         h5_write_sparse(create_group(f, "objective"), objective(model)[rxnp])
         h5_write_sparse(create_group(f, "stoichiometry"), stoichiometry(model)[metp, rxnp])
         let (lbs, ubs) = variable_bounds(model)

--- a/src/io/show/AbstractMetabolicModel.jl
+++ b/src/io/show/AbstractMetabolicModel.jl
@@ -6,6 +6,6 @@ Pretty printing of everything metabolic-modelish.
 function Base.show(io::Base.IO, ::MIME"text/plain", m::AbstractMetabolicModel)
     print(
         io,
-        "$(typeof(m))(#= $(reaction_count(m)) reactions, $(n_metabolites(m)) metabolites =#)",
+        "$(typeof(m))(#= $(reaction_count(m)) reactions, $(metabolite_count(m)) metabolites =#)",
     )
 end

--- a/src/reconstruction/MatrixCoupling.jl
+++ b/src/reconstruction/MatrixCoupling.jl
@@ -363,7 +363,10 @@ end
 end
 
 @_remove_fn metabolite MatrixCoupling String inplace plural begin
-    remove_metabolites!(model, Int.(indexin(metabolite_ids, metabolite_ids(model))))
+    remove_metabolites!(
+        model,
+        Int.(indexin(metabolite_ids, Accessors.metabolite_ids(model))),
+    )
 end
 
 @_remove_fn metabolite MatrixCoupling String begin
@@ -371,7 +374,10 @@ end
 end
 
 @_remove_fn metabolite MatrixCoupling String plural begin
-    remove_metabolites(model, Int.(indexin(metabolite_ids, metabolite_ids(model))))
+    remove_metabolites(
+        model,
+        Int.(indexin(metabolite_ids, Accessors.metabolite_ids(model))),
+    )
 end
 
 """

--- a/src/reconstruction/MatrixCoupling.jl
+++ b/src/reconstruction/MatrixCoupling.jl
@@ -363,7 +363,7 @@ end
 end
 
 @_remove_fn metabolite MatrixCoupling String inplace plural begin
-    remove_metabolites!(model, Int.(indexin(metabolite_ids, metabolites(model))))
+    remove_metabolites!(model, Int.(indexin(metabolite_ids, metabolite_ids(model))))
 end
 
 @_remove_fn metabolite MatrixCoupling String begin
@@ -371,7 +371,7 @@ end
 end
 
 @_remove_fn metabolite MatrixCoupling String plural begin
-    remove_metabolites(model, Int.(indexin(metabolite_ids, metabolites(model))))
+    remove_metabolites(model, Int.(indexin(metabolite_ids, metabolite_ids(model))))
 end
 
 """

--- a/src/reconstruction/MatrixModel.jl
+++ b/src/reconstruction/MatrixModel.jl
@@ -12,7 +12,7 @@ function add_reactions!(model::MatrixModel, rxns::Vector{Reaction})
     ubs = zeros(length(rxns))
     for (j, rxn) in enumerate(rxns)
         req = rxn.metabolites
-        for (i, v) in zip(indexin(keys(req), metabolites(model)), values(req))
+        for (i, v) in zip(indexin(keys(req), metabolite_ids(model)), values(req))
             push!(J, j)
             push!(I, i)
             push!(V, v)
@@ -21,7 +21,7 @@ function add_reactions!(model::MatrixModel, rxns::Vector{Reaction})
         lbs[j] = rxn.lower_bound
         ubs[j] = rxn.upper_bound
     end
-    Sadd = sparse(I, J, V, n_metabolites(model), length(rxns))
+    Sadd = sparse(I, J, V, metabolite_count(model), length(rxns))
     model.S = [model.S Sadd]
     model.c = dropzeros([model.c; zeros(length(rxns))]) # does not add an objective info from rxns
     model.xu = ubs
@@ -370,7 +370,7 @@ end
             any(in.(findnz(model.S[:, ridx])[1], Ref(metabolite_idxs)))
         ],
     )
-    mask = .!in.(1:n_metabolites(model), Ref(metabolite_idxs))
+    mask = .!in.(1:metabolite_count(model), Ref(metabolite_idxs))
     model.S = model.S[mask, :]
     model.b = model.b[mask]
     model.mets = model.mets[mask]
@@ -392,7 +392,7 @@ end
 end
 
 @_remove_fn metabolite MatrixModel String inplace plural begin
-    remove_metabolites!(model, Int.(indexin(metabolite_ids, metabolites(model))))
+    remove_metabolites!(model, Int.(indexin(metabolite_ids, metabolite_ids(model))))
 end
 
 @_remove_fn metabolite MatrixModel String begin
@@ -400,7 +400,7 @@ end
 end
 
 @_remove_fn metabolite MatrixModel String plural begin
-    remove_metabolites(model, Int.(indexin(metabolite_ids, metabolites(model))))
+    remove_metabolites(model, Int.(indexin(metabolite_ids, metabolite_ids(model))))
 end
 
 """

--- a/src/reconstruction/MatrixModel.jl
+++ b/src/reconstruction/MatrixModel.jl
@@ -392,7 +392,10 @@ end
 end
 
 @_remove_fn metabolite MatrixModel String inplace plural begin
-    remove_metabolites!(model, Int.(indexin(metabolite_ids, metabolite_ids(model))))
+    remove_metabolites!(
+        model,
+        Int.(indexin(metabolite_ids, Accessors.metabolite_ids(model))),
+    )
 end
 
 @_remove_fn metabolite MatrixModel String begin
@@ -400,7 +403,10 @@ end
 end
 
 @_remove_fn metabolite MatrixModel String plural begin
-    remove_metabolites(model, Int.(indexin(metabolite_ids, metabolite_ids(model))))
+    remove_metabolites(
+        model,
+        Int.(indexin(metabolite_ids, Accessors.metabolite_ids(model))),
+    )
 end
 
 """

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -75,6 +75,10 @@ function make_optimization_model(
             label = Symbol(semname, :_lbs)
             optimization_model[label] = constraints
             set_name.(constraints, "$label")
+            # TODO: this actually uses the semantic matrix transposed, but
+            # that's right. Fix: transpose all other semantics because having
+            # the stoichiometry in the "right" way is quite crucial for folks
+            # being able to reason about stuff.
             constraints = @constraint(optimization_model, smtx * x .<= sub)
             label = Symbol(semname, :_ubs)
             optimization_model[label] = constraints

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -205,7 +205,7 @@ values_vec(:reaction, flux_balance_analysis(model, ...))
 """
 function values_vec(semantics::Symbol, res::ModelWithResult{<:Model})
     s = Accessors.Internal.semantics(semantics)
-    is_solved(res.result) ? s.mapping_matrix(res.model)' * value.(res.result[:x]) : nothing
+    is_solved(res.result) ? s.mapping_matrix(res.model) * value.(res.result[:x]) : nothing
 end
 
 """
@@ -252,7 +252,7 @@ values_dict(:reaction, flux_balance_analysis(model, ...))
 function values_dict(semantics::Symbol, res::ModelWithResult{<:Model})
     s = Accessors.Internal.semantics(semantics)
     is_solved(res.result) ?
-    Dict(s.ids(res.model) .=> s.mapping_matrix(res.model)' * value.(res.result[:x])) :
+    Dict(s.ids(res.model) .=> s.mapping_matrix(res.model) * value.(res.result[:x])) :
     nothing
 end
 

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -62,16 +62,23 @@ function make_optimization_model(
             continue
         elseif typeof(bounds) <: AbstractVector{Float64}
             # equality bounds
-            c = @constraint(optimization_model, sem.mapping_matrix(model) * x .== bounds)
-            set_name.(c, "$(semname)_eqs")
+            constraints =
+                @constraint(optimization_model, sem.mapping_matrix(model) * x .== bounds)
+            label = Symbol(semname, :_eqs)
+            optimization_model[label] = constraints
+            set_name.(c, "$label")
         elseif typeof(bounds) <: Tuple{<:AbstractVector{Float64},<:AbstractVector{Float64}}
             # lower/upper interval bounds
             slb, sub = bounds
             smtx = sem.mapping_matrix(model)
-            c = @constraint(optimization_model, slb .<= smtx * x)
-            set_name.(c, "$(semname)_lbs")
-            c = @constraint(optimization_model, smtx * x .<= sub)
-            set_name.(c, "$(semname)_ubs")
+            constraints = @constraint(optimization_model, slb .<= smtx * x)
+            label = Symbol(semname, :_lbs)
+            optimization_model[label] = constraints
+            set_name.(c, "$label")
+            constraints = @constraint(optimization_model, smtx * x .<= sub)
+            label = Symbol(semname, :_ubs)
+            optimization_model[label] = constraints
+            set_name.(c, "$label")
         else
             # if the bounds returned something weird, complain loudly.
             throw(

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -89,9 +89,6 @@ function make_optimization_model(
         end
     end
 
-    # make stoichiometry balanced
-    @constraint(optimization_model, mb, stoichiometry(model) * x .== balance(model)) # mass balance
-
     # add coupling constraints
     C = coupling(model)
     if !isempty(C)

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -66,7 +66,7 @@ function make_optimization_model(
                 @constraint(optimization_model, sem.mapping_matrix(model) * x .== bounds)
             label = Symbol(semname, :_eqs)
             optimization_model[label] = constraints
-            set_name.(c, "$label")
+            set_name.(constraints, "$label")
         elseif typeof(bounds) <: Tuple{<:AbstractVector{Float64},<:AbstractVector{Float64}}
             # lower/upper interval bounds
             slb, sub = bounds
@@ -74,11 +74,11 @@ function make_optimization_model(
             constraints = @constraint(optimization_model, slb .<= smtx * x)
             label = Symbol(semname, :_lbs)
             optimization_model[label] = constraints
-            set_name.(c, "$label")
+            set_name.(constraints, "$label")
             constraints = @constraint(optimization_model, smtx * x .<= sub)
             label = Symbol(semname, :_ubs)
             optimization_model[label] = constraints
-            set_name.(c, "$label")
+            set_name.(constraints, "$label")
         else
             # if the bounds returned something weird, complain loudly.
             throw(

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -62,6 +62,9 @@ function make_optimization_model(
     end
 
     # go over the semantics and add bounds if there are any
+    # TODO for use in sampling and other things, it would be nice to have
+    # helper functions to make a complete matrix of equality and interval
+    # constraints.
     for (semname, sem) in Accessors.Internal.get_semantics()
         bounds = sem.bounds(model)
         if isnothing(bounds)

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -68,7 +68,9 @@ function make_optimization_model(
             continue
         elseif typeof(bounds) <: AbstractVector{Float64}
             # equality bounds
-            label(semname, :eqs,
+            label(
+                semname,
+                :eqs,
                 @constraint(optimization_model, sem.mapping_matrix(model) * x .== bounds)
             )
         elseif typeof(bounds) <: Tuple{<:AbstractVector{Float64},<:AbstractVector{Float64}}

--- a/src/types/accessors/AbstractMetabolicModel.jl
+++ b/src/types/accessors/AbstractMetabolicModel.jl
@@ -199,7 +199,7 @@ In SBML, these are usually called "gene products" but we write `genes` for
 simplicity.
 """
 function genes(a::AbstractMetabolicModel)::Vector{String}
-    return []
+    String[]
 end
 
 """

--- a/src/types/accessors/AbstractMetabolicModel.jl
+++ b/src/types/accessors/AbstractMetabolicModel.jl
@@ -23,7 +23,7 @@ genetic material and virtual cell volume, etc. To simplify the view of the model
 contents use [`reaction_variables`](@ref).
 """
 function variable_ids(a::AbstractMetabolicModel)::Vector{String}
-    missing_impl_error(variables, (a,))
+    missing_impl_error(variable_ids, (a,))
 end
 
 """
@@ -46,53 +46,13 @@ $(TYPEDSIGNATURES)
 Get the lower and upper solution bounds of a model.
 """
 function variable_bounds(a::AbstractMetabolicModel)::Tuple{Vector{Float64},Vector{Float64}}
-    missing_impl_error(bounds, (a,))
+    missing_impl_error(variable_bounds, (a,))
 end
 
 """
 Shortcut for writing [`variable_bounds`](@ref).
 """
 const bounds = variable_bounds
-
-"""
-$(TYPEDSIGNATURES)
-
-Return a vector of metabolite identifiers in a model. The vector precisely
-corresponds to the rows in [`stoichiometry`](@ref) matrix.
-
-As with [`variables`](@ref)s, some metabolites in models may be virtual,
-representing purely technical equality constraints.
-"""
-function metabolites(a::AbstractMetabolicModel)::Vector{String}
-    missing_impl_error(metabolites, (a,))
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Get the number of metabolites in a model.
-"""
-function n_metabolites(a::AbstractMetabolicModel)::Int
-    length(metabolites(a))
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Get the sparse stoichiometry matrix of a model.
-"""
-function stoichiometry(a::AbstractMetabolicModel)::SparseMat
-    missing_impl_error(stoichiometry, (a,))
-end
-
-"""
-$(TYPEDSIGNATURES)
-
-Get the sparse balance vector of a model.
-"""
-function balance(a::AbstractMetabolicModel)::SparseVec
-    return spzeros(n_metabolites(a))
-end
 
 """
 $(TYPEDSIGNATURES)
@@ -130,6 +90,26 @@ flux, such as with separate bidirectional reactions.
 Shortcut for writing [`reaction_ids`](@ref).
 """
 const reactions = reaction_ids
+
+@make_variable_semantics(
+    :metabolite,
+    "metabolites",
+    """
+Metabolite values represent the over-time change of abundance of individual
+metabolites in the model. To reach a steady state, models typically constraint
+these to be zero.
+"""
+)
+
+"""
+A shortcut for [`metabolite_ids`](@ref).
+"""
+const metabolites = metabolite_ids
+
+"""
+The usual name of [`metabolite_variables_matrix`](@ref).
+"""
+const stoichiometry = metabolite_variables_matrix
 
 @make_variable_semantics(
     :enzyme,
@@ -307,7 +287,7 @@ function reaction_stoichiometry(
     m::AbstractMetabolicModel,
     rid::String,
 )::Dict{String,Float64}
-    mets = metabolites(m)
+    mets = metabolite_ids(m)
     Dict(
         mets[k] => v for (k, v) in
         zip(findnz(stoichiometry(m)[:, first(indexin([rid], variable_ids(m)))])...)

--- a/src/types/accessors/ModelWrapper.jl
+++ b/src/types/accessors/ModelWrapper.jl
@@ -15,7 +15,7 @@ end
 # [`AbstractMetabolicModel`](@ref).
 #
 
-@inherit_model_methods_fn AbstractModelWrapper () unwrap_model () variables metabolites stoichiometry bounds balance objective coupling n_coupling_constraints coupling_bounds genes n_genes precache! model_notes model_annotations
+@inherit_model_methods_fn AbstractModelWrapper () unwrap_model () variable_count variable_ids variable_bounds objective coupling n_coupling_constraints coupling_bounds genes n_genes precache! model_notes model_annotations
 
 @inherit_model_methods_fn AbstractModelWrapper (rid::String,) unwrap_model (rid,) reaction_gene_associations reaction_subsystem reaction_stoichiometry reaction_annotations reaction_notes reaction_isozymes
 

--- a/src/types/accessors/ModelWrapper.jl
+++ b/src/types/accessors/ModelWrapper.jl
@@ -15,7 +15,12 @@ end
 # [`AbstractMetabolicModel`](@ref).
 #
 
-@inherit_model_methods_fn AbstractModelWrapper () unwrap_model () variable_count variable_ids variable_bounds objective coupling n_coupling_constraints coupling_bounds genes n_genes precache! model_notes model_annotations
+# TODO make some functionality that allows folks to clearly declare that stuff
+# like variable_count, somesemantic_count or somesemantic_variables_matrix did
+# not change and can be safely inherited instead of being recreated from the
+# more complex data.
+
+@inherit_model_methods_fn AbstractModelWrapper () unwrap_model () variable_ids variable_bounds objective coupling n_coupling_constraints coupling_bounds genes n_genes precache! model_notes model_annotations
 
 @inherit_model_methods_fn AbstractModelWrapper (rid::String,) unwrap_model (rid,) reaction_gene_associations reaction_subsystem reaction_stoichiometry reaction_annotations reaction_notes reaction_isozymes
 

--- a/src/types/accessors/bits/semantics.jl
+++ b/src/types/accessors/bits/semantics.jl
@@ -230,7 +230,7 @@ safety reasons, this is never automatically inherited by wrappers.
 """,
         ),
         :(function $mapping_mtx(a::AbstractMetabolicModel)::SparseMat
-            make_mapping_mtx(variable_ids(a), $ids(a), $mapping(a))
+            make_mapping_mtx($ids(a), variable_ids(a), $mapping(a))
         end),
     )
 

--- a/src/types/accessors/bits/semantics.jl
+++ b/src/types/accessors/bits/semantics.jl
@@ -182,7 +182,7 @@ vector returned by [`$ids`].
 """,
         ),
         :(function $count(a::AbstractMetabolicModel)::Int
-            0
+            length($ids(a))
         end),
     )
 
@@ -244,13 +244,9 @@ no bounds, or a vector of floats with equality bounds, or a tuple of 2 vectors
 with lower and upper bounds.
 """,
         ),
-        :(
-            function $bounds(
-                a::AbstractMetabolicModel,
-            )::Union{Nothing,Vector{Float64},Tuple{Vector{Float64},Vector{Float64}}}
-                nothing
-            end
-        ),
+        :(function $bounds(a::AbstractMetabolicModel)
+            $(sym == :metabolite ? :(spzeros($count(a))) : nothing)
+        end),
     )
 
     Base.eval.(Ref(themodule), [idsfn, countfn, mappingfn, mtxfn, boundsfn])
@@ -271,16 +267,9 @@ with lower and upper bounds.
         end),
     )
 
-    Base.eval(
-        themodule,
-        :(
-            function $bounds(
-                w::AbstractModelWrapper,
-            )::Union{Nothing,Vector{Float64},Tuple{Vector{Float64},Vector{Float64}}}
-                $bounds(unwrap_model(w))
-            end
-        ),
-    )
+    Base.eval(themodule, :(function $bounds(w::AbstractModelWrapper)
+        $bounds(unwrap_model(w))
+    end))
 
     # TODO here we would normally also overload the matrix function, but that
     # one will break once anyone touches variables of the models (which is quite

--- a/src/types/accessors/bits/semantics.jl
+++ b/src/types/accessors/bits/semantics.jl
@@ -5,27 +5,27 @@ A helper function to quickly create a sparse matrix from a dictionary that
 describes it. Reverse of [`make_mapping_dict`](@ref).
 """
 function make_mapping_mtx(
-    vars::Vector{String},
     semantics::Vector{String},
-    var_sem_val::Dict{String,Dict{String,Float64}},
+    vars::Vector{String},
+    sem_var_val::Dict{String,Dict{String,Float64}},
 )::Types.SparseMat
     # TODO: move this to general utils or so
-    rowidx = Dict(vars .=> 1:length(vars))
-    colidx = Dict(semantics .=> 1:length(semantics))
-    n = sum(length.(values(var_sem_val)))
+    rowidx = Dict(semantics .=> 1:length(semantics))
+    colidx = Dict(vars .=> 1:length(vars))
+    n = sum(length.(values(sem_var_val)))
     R = Vector{Int}(undef, n)
     C = Vector{Int}(undef, n)
     V = Vector{Float64}(undef, n)
     i = 1
-    for (cid, col_val) in var_sem_val
-        for (rid, val) in col_val
+    for (rid, var_val) in sem_var_val
+        for (cid, val) in var_val
             R[i] = rowidx[rid]
             C[i] = colidx[cid]
             V[i] = val
             i += 1
         end
     end
-    sparse(R, C, V, length(vars), length(semantics))
+    sparse(R, C, V, length(semantics), length(vars))
 end
 
 """
@@ -35,15 +35,19 @@ A helper function to quickly create a sparse matrix from a dictionary that
 describes it. Reverse of [`make_mapping_mtx`](@ref).
 """
 function make_mapping_dict(
-    vars::Vector{String},
     semantics::Vector{String},
+    vars::Vector{String},
     mtx::Types.SparseMat,
 )::Dict{String,Dict{String,Float64}}
-    # TODO: move this to general utils
-    Dict(
-        sid => Dict(vars[vidx] => val for (vidx, val) in zip(findnz(mtx[:, sidx])...)) for
-        (sidx, sid) in enumerate(semantics)
-    )
+    x = Dict{String,Dict{String,Float64}}()
+    for (ridx, cidx, val) in zip(findnz(mtx)...)
+        if haskey(x, semantics[ridx])
+            x[semantics[ridx]][vars[cidx]] = val
+        else
+            x[semantics[ridx]] = Dict{String,Float64}(vars[cidx] => val)
+        end
+    end
+    x
 end
 
 """
@@ -67,13 +71,13 @@ Base.@kwdef struct Semantics
     count::Function
 
     """
-    Returns a mapping of semantic values to variables IDs in the model.
+    Returns a mapping of semantic values to variables IDs and their stoichiometry.
     """
     mapping::Function
 
     """
-    Same as `mapping` but returns a matrix (with variables in rows and the
-    semantic values in columns), which is possibly more efficient or handy in
+    Same as `mapping` but returns a matrix (with semantic values in rows and
+    the variables in columns), which is possibly more efficient or handy in
     specific cases.
     """
     mapping_matrix::Function
@@ -219,7 +223,7 @@ To improve the performance, you may want to use [`$mapping_mtx`](@ref).
 
 Bipartite mapping of $name described by the model to the actual
 variables in the model, described as a sparse matrix mapping with rows
-corresponding to model variables and columns corresponding to $name.
+corresponding to $name and columns corresponding to model variables.
 
 By default, this is derived from [`$mapping`](@ref) in all models. For
 safety reasons, this is never automatically inherited by wrappers.

--- a/src/types/models/CommunityModel.jl
+++ b/src/types/models/CommunityModel.jl
@@ -109,16 +109,16 @@ function Accessors.variable_count(cm::CommunityModel)
     return num_model_reactions + num_env_metabolites
 end
 
-function Accessors.metabolites(cm::CommunityModel)
+function Accessors.metabolite_ids(cm::CommunityModel)
     mets = [
         cm.name_lookup[id][:metabolites][mid] for (id, m) in cm.members for
-        mid in metabolites(m.model)
+        mid in metabolite_ids(m.model)
     ]
     return [mets; "ENV_" .* [envlink.metabolite_id for envlink in cm.environmental_links]]
 end
 
-function Accessors.n_metabolites(cm::CommunityModel)
-    num_model_constraints = sum(n_metabolites(m.model) for m in values(cm.members))
+function Accessors.metabolite_count(cm::CommunityModel)
+    num_model_constraints = sum(metabolite_count(m.model) for m in values(cm.members))
     num_env_metabolites = length(cm.environmental_links)
     return num_model_constraints + num_env_metabolites
 end
@@ -128,8 +128,8 @@ Accessors.genes(cm::CommunityModel) =
 
 Accessors.n_genes(cm::CommunityModel) = sum(n_genes(m.model) for m in values(cm.members))
 
-Accessors.balance(cm::CommunityModel) = [
-    vcat([balance(m.model) for m in values(cm.members)]...)
+Accessors.metabolite_bounds(cm::CommunityModel) = [
+    vcat([metabolite_bounds(m.model) for m in values(cm.members)]...)
     spzeros(length(cm.environmental_links))
 ]
 

--- a/src/types/models/HDF5Model.jl
+++ b/src/types/models/HDF5Model.jl
@@ -46,12 +46,12 @@ end
 
 Accessors.Internal.@all_variables_are_reactions HDF5Model
 
-function Accessors.n_metabolites(model::HDF5Model)::Int
+function Accessors.metabolite_count(model::HDF5Model)::Int
     precache!(model)
     length(model.h5["metabolites"])
 end
 
-function Accessors.metabolites(model::HDF5Model)::Vector{String}
+function Accessors.metabolite_ids(model::HDF5Model)::Vector{String}
     precache!(model)
     read(model.h5["metabolites"])
 end
@@ -66,7 +66,7 @@ function Accessors.variable_bounds(model::HDF5Model)::Tuple{Vector{Float64},Vect
     (HDF5.readmmap(model.h5["lower_bounds"]), HDF5.readmmap(model.h5["upper_bounds"]))
 end
 
-function Accessors.balance(model::HDF5Model)::SparseVec
+function Accessors.metabolite_bounds(model::HDF5Model)::SparseVec
     precache!(model)
     h5_read_sparse(SparseVec, model.h5["balance"])
 end

--- a/src/types/models/HDF5Model.jl
+++ b/src/types/models/HDF5Model.jl
@@ -58,10 +58,17 @@ function Accessors.metabolite_ids(model::HDF5Model)::Vector{String}
     read(model.h5["metabolites"])
 end
 
-function Accessors.stoichiometry(model::HDF5Model)::SparseMat
+function Accessors.metabolite_variables_matrix(model::HDF5Model)::SparseMat
     precache!(model)
     h5_read_sparse(SparseMat, model.h5["stoichiometry"])
 end
+
+Accessors.metabolite_variables(model::HDF5Model)::Dict{String,Dict{String,Float}} =
+    Accessors.Internal.make_mapping_dict(
+        metabolite_ids(m),
+        variable_ids(m),
+        metabolite_variables_matrix(m),
+    )
 
 function Accessors.variable_bounds(model::HDF5Model)::Tuple{Vector{Float64},Vector{Float64}}
     precache!(model)

--- a/src/types/models/HDF5Model.jl
+++ b/src/types/models/HDF5Model.jl
@@ -26,6 +26,8 @@ mutable struct HDF5Model <: AbstractMetabolicModel
     HDF5Model(filename::String) = new(nothing, filename)
 end
 
+# TODO this might need to store the extra semantics now
+
 function Accessors.precache!(model::HDF5Model)::Nothing
     if isnothing(model.h5)
         model.h5 = h5open(model.filename, "r")

--- a/src/types/models/JSONModel.jl
+++ b/src/types/models/JSONModel.jl
@@ -73,14 +73,14 @@ _parse_notes(x)::Notes = _parse_annotations(x)
 
 Accessors.variable_count(model::JSONModel) = length(model.rxns)
 
-Accessors.n_metabolites(model::JSONModel) = length(model.mets)
+Accessors.metabolite_count(model::JSONModel) = length(model.mets)
 
 Accessors.n_genes(model::JSONModel) = length(model.genes)
 
 Accessors.variable_ids(model::JSONModel) =
     [_json_rxn_name(r, i) for (i, r) in enumerate(model.rxns)]
 
-Accessors.metabolites(model::JSONModel) =
+Accessors.metabolite_ids(model::JSONModel) =
     [_json_met_name(m, i) for (i, m) in enumerate(model.mets)]
 
 Accessors.genes(model::JSONModel) =
@@ -90,7 +90,7 @@ Accessors.Internal.@all_variables_are_reactions JSONModel
 
 function Accessors.stoichiometry(model::JSONModel)
     rxn_ids = variable_ids(model)
-    met_ids = metabolites(model)
+    met_ids = metabolite_ids(model)
 
     n_entries = 0
     for r in model.rxns
@@ -205,7 +205,7 @@ function Base.convert(::Type{JSONModel}, mm::AbstractMetabolicModel)
     end
 
     rxn_ids = variable_ids(mm)
-    met_ids = metabolites(mm)
+    met_ids = metabolite_ids(mm)
     gene_ids = genes(mm)
     S = stoichiometry(mm)
     lbs, ubs = variable_bounds(mm)

--- a/src/types/models/MATModel.jl
+++ b/src/types/models/MATModel.jl
@@ -36,7 +36,13 @@ function Accessors.metabolite_ids(m::MATModel)::Vector{String}
     end
 end
 
-Accessors.stoichiometry(m::MATModel) = sparse(m.mat["S"])
+Accessors.metabolite_variables_matrix(m::MATModel) = sparse(m.mat["S"])
+
+Accessors.metabolite_variables(m::MATModel) = Accessors.Internal.make_mapping_dict(
+    metabolite_ids(m),
+    variable_ids(m),
+    metabolite_variables_matrix(m),
+)
 
 Accessors.variable_bounds(m::MATModel) = (
     reshape(get(m.mat, "lb", fill(-Inf, variable_count(m), 1)), variable_count(m)),

--- a/src/types/models/MatrixModel.jl
+++ b/src/types/models/MatrixModel.jl
@@ -51,14 +51,14 @@ Accessors.variable_ids(a::MatrixModel)::Vector{String} = a.rxns
 
 Accessors.Internal.@all_variables_are_reactions MatrixModel
 
-Accessors.metabolites(a::MatrixModel)::Vector{String} = a.mets
+Accessors.metabolite_ids(a::MatrixModel)::Vector{String} = a.mets
 
 Accessors.stoichiometry(a::MatrixModel)::SparseMat = a.S
 
 Accessors.variable_bounds(a::MatrixModel)::Tuple{Vector{Float64},Vector{Float64}} =
     (a.xl, a.xu)
 
-Accessors.balance(a::MatrixModel)::SparseVec = a.b
+Accessors.metabolite_bounds(a::MatrixModel)::SparseVec = a.b
 
 Accessors.objective(a::MatrixModel)::SparseVec = a.c
 
@@ -99,12 +99,12 @@ function Base.convert(::Type{MatrixModel}, m::M) where {M<:AbstractMetabolicMode
     (xl, xu) = variable_bounds(m)
     MatrixModel(
         stoichiometry(m),
-        balance(m),
+        metabolite_bounds(m),
         objective(m),
         xl,
         xu,
         variable_ids(m),
-        metabolites(m),
+        metabolite_ids(m),
         Vector{Maybe{GeneAssociationsDNF}}([
             reaction_gene_associations(m, id) for id in variable_ids(m)
         ]),

--- a/src/types/models/MatrixModel.jl
+++ b/src/types/models/MatrixModel.jl
@@ -53,7 +53,13 @@ Accessors.Internal.@all_variables_are_reactions MatrixModel
 
 Accessors.metabolite_ids(a::MatrixModel)::Vector{String} = a.mets
 
-Accessors.stoichiometry(a::MatrixModel)::SparseMat = a.S
+Accessors.metabolite_variables_matrix(a::MatrixModel)::SparseMat = a.S
+
+Accessors.metabolite_variables(a::MatrixModel) = Accessors.Internal.make_mapping_dict(
+    metabolite_ids(a),
+    variable_ids(a),
+    metabolite_variables_matrix(a),
+)
 
 Accessors.variable_bounds(a::MatrixModel)::Tuple{Vector{Float64},Vector{Float64}} =
     (a.xl, a.xu)

--- a/src/types/models/ObjectModel.jl
+++ b/src/types/models/ObjectModel.jl
@@ -60,9 +60,10 @@ Accessors.variable_count(model::ObjectModel)::Int = length(model.reactions)
 
 Accessors.Internal.@all_variables_are_reactions ObjectModel
 
-Accessors.metabolites(model::ObjectModel)::StringVecType = collect(keys(model.metabolites))
+Accessors.metabolite_ids(model::ObjectModel)::StringVecType =
+    collect(keys(model.metabolites))
 
-Accessors.n_metabolites(model::ObjectModel)::Int = length(model.metabolites)
+Accessors.metabolite_count(model::ObjectModel)::Int = length(model.metabolites)
 
 Accessors.genes(model::ObjectModel)::StringVecType = collect(keys(model.genes))
 
@@ -85,7 +86,7 @@ function Accessors.stoichiometry(model::ObjectModel)::SparseMat
 
     # establish the ordering
     rxns = variable_ids(model)
-    met_idx = Dict(mid => i for (i, mid) in enumerate(metabolites(model)))
+    met_idx = Dict(mid => i for (i, mid) in enumerate(metabolite_ids(model)))
 
     # fill the matrix entries
     for (ridx, rid) in enumerate(rxns)
@@ -101,13 +102,14 @@ function Accessors.stoichiometry(model::ObjectModel)::SparseMat
             push!(SV, coeff)
         end
     end
-    return SparseArrays.sparse(MI, RI, SV, n_metabolites(model), variable_count(model))
+    return SparseArrays.sparse(MI, RI, SV, metabolite_count(model), variable_count(model))
 end
 
 Accessors.variable_bounds(model::ObjectModel)::Tuple{Vector{Float64},Vector{Float64}} =
     (lower_bounds(model), upper_bounds(model))
 
-Accessors.balance(model::ObjectModel)::SparseVec = spzeros(length(model.metabolites))
+Accessors.metabolite_bounds(model::ObjectModel)::SparseVec =
+    spzeros(length(model.metabolites))
 
 Accessors.objective(model::ObjectModel)::SparseVec =
     sparse([get(model.objective, rid, 0.0) for rid in keys(model.reactions)])
@@ -187,7 +189,7 @@ function Base.convert(::Type{ObjectModel}, model::AbstractMetabolicModel)
     modelgenes = OrderedDict{String,Gene}()
 
     gids = genes(model)
-    metids = metabolites(model)
+    metids = metabolite_ids(model)
     rxnids = variable_ids(model)
 
     for gid in gids

--- a/src/types/models/ObjectModel.jl
+++ b/src/types/models/ObjectModel.jl
@@ -69,40 +69,18 @@ Accessors.genes(model::ObjectModel)::StringVecType = collect(keys(model.genes))
 
 Accessors.n_genes(model::ObjectModel)::Int = length(model.genes)
 
-function Accessors.stoichiometry(model::ObjectModel)::SparseMat
-    n_entries = 0
-    for (_, r) in model.reactions
-        for _ in r.metabolites
-            n_entries += 1
+function Accessors.metabolite_variables(model::ObjectModel)
+    x = Dict{String,Dict{String,Float64}}()
+    for (rid, r) in model.reactions
+        for (mid, coeff) in r.metabolites
+            if haskey(x, mid)
+                x[mid][rid] = coeff
+            else
+                x[mid] = Dict{String,Float64}(rid => coeff)
+            end
         end
     end
-
-    MI = Vector{Int}()
-    RI = Vector{Int}()
-    SV = Vector{Float64}()
-    sizehint!(MI, n_entries)
-    sizehint!(RI, n_entries)
-    sizehint!(SV, n_entries)
-
-    # establish the ordering
-    rxns = variable_ids(model)
-    met_idx = Dict(mid => i for (i, mid) in enumerate(metabolite_ids(model)))
-
-    # fill the matrix entries
-    for (ridx, rid) in enumerate(rxns)
-        for (mid, coeff) in model.reactions[rid].metabolites
-            haskey(met_idx, mid) || throw(
-                DomainError(
-                    mid,
-                    "Metabolite $(mid) not found in model but occurs in stoichiometry of $(rid)",
-                ),
-            )
-            push!(MI, met_idx[mid])
-            push!(RI, ridx)
-            push!(SV, coeff)
-        end
-    end
-    return SparseArrays.sparse(MI, RI, SV, metabolite_count(model), variable_count(model))
+    x
 end
 
 Accessors.variable_bounds(model::ObjectModel)::Tuple{Vector{Float64},Vector{Float64}} =

--- a/src/types/models/SBMLModel.jl
+++ b/src/types/models/SBMLModel.jl
@@ -42,7 +42,7 @@ Accessors.variable_ids(model::SBMLModel)::Vector{String} = model.reaction_ids
 
 Accessors.Internal.@all_variables_are_reactions SBMLModel
 
-Accessors.metabolites(model::SBMLModel)::Vector{String} = model.metabolite_ids
+Accessors.metabolite_ids(model::SBMLModel)::Vector{String} = model.metabolite_ids
 
 function Accessors.stoichiometry(model::SBMLModel)::SparseMat
 
@@ -78,7 +78,7 @@ function Accessors.stoichiometry(model::SBMLModel)::SparseMat
             push!(Vals, isnothing(sr.stoichiometry) ? 1.0 : sr.stoichiometry)
         end
     end
-    return sparse(Rows, Cols, Vals, n_metabolites(model), reaction_count(model))
+    return sparse(Rows, Cols, Vals, metabolite_count(model), reaction_count(model))
 end
 
 function Accessors.variable_bounds(model::SBMLModel)::Tuple{Vector{Float64},Vector{Float64}}
@@ -134,7 +134,7 @@ function Accessors.variable_bounds(model::SBMLModel)::Tuple{Vector{Float64},Vect
     )
 end
 
-Accessors.balance(model::SBMLModel)::SparseVec = spzeros(n_metabolites(model))
+Accessors.metabolite_bounds(model::SBMLModel)::SparseVec = spzeros(metabolite_count(model))
 
 function Accessors.objective(model::SBMLModel)::SparseVec
     res = sparsevec([], [], reaction_count(model))
@@ -279,7 +279,7 @@ function Base.convert(::Type{SBMLModel}, mm::AbstractMetabolicModel)
         return mm
     end
 
-    mets = metabolites(mm)
+    mets = metabolite_ids(mm)
     rxns = variable_ids(mm)
     stoi = stoichiometry(mm)
     (lbs, ubs) = variable_bounds(mm)

--- a/src/types/wrappers/EqualGrowthCommunityModel.jl
+++ b/src/types/wrappers/EqualGrowthCommunityModel.jl
@@ -36,7 +36,7 @@ Accessors.metabolite_bounds(cm::EqualGrowthCommunityModel) = [
 ]
 
 function Accessors.stoichiometry(cm::EqualGrowthCommunityModel)
-
+    # TODO this needs a rework
     S = stoichiometry(cm.inner)
     obj_col = spzeros(size(S, 1))
 

--- a/src/types/wrappers/EqualGrowthCommunityModel.jl
+++ b/src/types/wrappers/EqualGrowthCommunityModel.jl
@@ -24,14 +24,14 @@ Accessors.variable_ids(cm::EqualGrowthCommunityModel) =
 
 Accessors.variable_count(cm::EqualGrowthCommunityModel) = variable_count(cm.inner) + 1
 
-Accessors.metabolites(cm::EqualGrowthCommunityModel) =
-    [metabolites(cm.inner); [m.id for m in cm.inner.members]]
+Accessors.metabolite_ids(cm::EqualGrowthCommunityModel) =
+    [metabolite_ids(cm.inner); [m.id for m in cm.inner.members]]
 
-Accessors.n_metabolites(cm::EqualGrowthCommunityModel) =
-    n_metabolites(cm.inner) + length(cm.inner.members)
+Accessors.metabolite_count(cm::EqualGrowthCommunityModel) =
+    metabolite_count(cm.inner) + length(cm.inner.members)
 
-Accessors.balance(cm::EqualGrowthCommunityModel) = [
-    balance(cm.inner)
+Accessors.metabolite_bounds(cm::EqualGrowthCommunityModel) = [
+    metabolite_bounds(cm.inner)
     spzeros(length(cm.inner.members))
 ]
 

--- a/src/utils/fluxes.jl
+++ b/src/utils/fluxes.jl
@@ -7,7 +7,7 @@ produce them, given the flux distribution supplied in `flux_dict`.
 function metabolite_fluxes(model::AbstractMetabolicModel, flux_dict::Dict{String,Float64})
     S = stoichiometry(model)
     rids = variable_ids(model)
-    mids = metabolites(model)
+    mids = metabolite_ids(model)
 
     producing = Dict{String,Dict{String,Float64}}()
     consuming = Dict{String,Dict{String,Float64}}()

--- a/src/utils/looks_like.jl
+++ b/src/utils/looks_like.jl
@@ -111,8 +111,8 @@ metabolite id.
 
 # Example
 ```
-filter(looks_like_extracellular_metabolite, metabolites(model)) # returns strings
-findall(looks_like_extracellular_metabolite, metabolites(model)) # returns indices
+filter(looks_like_extracellular_metabolite, metabolite_ids(model)) # returns strings
+findall(looks_like_extracellular_metabolite, metabolite_ids(model)) # returns indices
 ```
 """
 function looks_like_extracellular_metabolite(
@@ -129,7 +129,7 @@ Shortcut for finding extracellular metabolite indexes in a model; arguments are
 forwarded to [`looks_like_extracellular_metabolite`](@ref).
 """
 find_extracellular_metabolites(m::AbstractMetabolicModel; kwargs...) =
-    findall(id -> looks_like_extracellular_metabolite(id; kwargs...), metabolites(m))
+    findall(id -> looks_like_extracellular_metabolite(id; kwargs...), metabolite_ids(m))
 
 """
 $(TYPEDSIGNATURES)
@@ -138,7 +138,7 @@ Shortcut for finding extracellular metabolite identifiers in a model; arguments 
 forwarded to [`looks_like_extracellular_metabolite`](@ref).
 """
 find_extracellular_metabolite_ids(m::AbstractMetabolicModel; kwargs...) =
-    findall(id -> looks_like_extracellular_metabolite(id; kwargs...), metabolites(m))
+    findall(id -> looks_like_extracellular_metabolite(id; kwargs...), metabolite_ids(m))
 
 @_is_reaction_fn "exchange" Identifiers.EXCHANGE_REACTIONS
 @_is_reaction_fn "transport" Identifiers.TRANSPORT_REACTIONS

--- a/src/wrappers/EnzymeConstrainedModel.jl
+++ b/src/wrappers/EnzymeConstrainedModel.jl
@@ -172,16 +172,16 @@ function Accessors.coupling_bounds(model::EnzymeConstrainedModel)
     )
 end
 
-Accessors.balance(model::EnzymeConstrainedModel) =
-    [balance(model.inner); spzeros(length(model.coupling_row_gene_product))]
+Accessors.metabolite_bounds(model::EnzymeConstrainedModel) =
+    [metabolite_bounds(model.inner); spzeros(length(model.coupling_row_gene_product))]
 
 Accessors.n_genes(model::EnzymeConstrainedModel) = length(model.coupling_row_gene_product)
 
 Accessors.genes(model::EnzymeConstrainedModel) =
     genes(model.inner)[[idx for (idx, _) in model.coupling_row_gene_product]]
 
-Accessors.metabolites(model::EnzymeConstrainedModel) =
-    [metabolites(model.inner); genes(model) .* "#enzyme_constrained"]
+Accessors.metabolite_ids(model::EnzymeConstrainedModel) =
+    [metabolite_ids(model.inner); genes(model) .* "#enzyme_constrained"]
 
-Accessors.n_metabolites(model::EnzymeConstrainedModel) =
-    n_metabolites(model.inner) + n_genes(model)
+Accessors.metabolite_count(model::EnzymeConstrainedModel) =
+    metabolite_count(model.inner) + n_genes(model)

--- a/src/wrappers/EnzymeConstrainedModel.jl
+++ b/src/wrappers/EnzymeConstrainedModel.jl
@@ -103,19 +103,28 @@ end
 
 function Accessors.reaction_variables_matrix(model::EnzymeConstrainedModel)
     rxnmat =
-        enzyme_constrained_column_reactions(model)' * reaction_variables_matrix(model.inner)
+        reaction_variables_matrix(model.inner) * enzyme_constrained_column_reactions(model)
     [
         rxnmat
-        spzeros(n_genes(model), size(rxnmat, 2))
+        spzeros(size(rxnmat, 1), n_genes(model))
     ]
 end
 
 Accessors.reaction_variables(model::EnzymeConstrainedModel) =
     Accessors.Internal.make_mapping_dict(
-        variable_ids(model),
         reaction_ids(model),
+        variable_ids(model),
         reaction_variables_matrix(model),
     ) # TODO currently inefficient
+
+Accessors.metabolite_ids(model::EnzymeConstrainedModel) =
+    [metabolite_ids(model.inner); genes(model) .* "#enzyme_constrained"]
+
+Accessors.metabolite_count(model::EnzymeConstrainedModel) =
+    metabolite_count(model.inner) + n_genes(model)
+
+Accessors.metabolite_bounds(model::EnzymeConstrainedModel) =
+    [metabolite_bounds(model.inner); spzeros(length(model.coupling_row_gene_product))]
 
 Accessors.enzyme_ids(model::EnzymeConstrainedModel) = genes(model)
 
@@ -172,16 +181,7 @@ function Accessors.coupling_bounds(model::EnzymeConstrainedModel)
     )
 end
 
-Accessors.metabolite_bounds(model::EnzymeConstrainedModel) =
-    [metabolite_bounds(model.inner); spzeros(length(model.coupling_row_gene_product))]
-
 Accessors.n_genes(model::EnzymeConstrainedModel) = length(model.coupling_row_gene_product)
 
 Accessors.genes(model::EnzymeConstrainedModel) =
     genes(model.inner)[[idx for (idx, _) in model.coupling_row_gene_product]]
-
-Accessors.metabolite_ids(model::EnzymeConstrainedModel) =
-    [metabolite_ids(model.inner); genes(model) .* "#enzyme_constrained"]
-
-Accessors.metabolite_count(model::EnzymeConstrainedModel) =
-    metabolite_count(model.inner) + n_genes(model)

--- a/src/wrappers/MaxMinDrivingForceModel.jl
+++ b/src/wrappers/MaxMinDrivingForceModel.jl
@@ -82,17 +82,17 @@ end
 Accessors.unwrap_model(model::MaxMinDrivingForceModel) = model.inner
 
 Accessors.variable_ids(model::MaxMinDrivingForceModel) =
-    ["mmdf"; "log " .* metabolites(model); "ΔG " .* reaction_ids(model)]
+    ["mmdf"; "log " .* metabolite_ids(model); "ΔG " .* reaction_ids(model)]
 
 Accessors.variable_count(model::MaxMinDrivingForceModel) =
-    1 + n_metabolites(model) + reaction_count(model)
+    1 + metabolite_count(model) + reaction_count(model)
 
 Accessors.metabolite_log_concentration_ids(model::MaxMinDrivingForceModel) =
-    "log " .* metabolites(model)
+    "log " .* metabolite_ids(model)
 Accessors.metabolite_log_concentration_count(model::MaxMinDrivingForceModel) =
-    n_metabolites(model)
+    metabolite_count(model)
 Accessors.metabolite_log_concentration_variables(model::MaxMinDrivingForceModel) =
-    Dict(mid => Dict(mid => 1.0) for mid in "log " .* metabolites(model))
+    Dict(mid => Dict(mid => 1.0) for mid in "log " .* metabolite_ids(model))
 
 Accessors.gibbs_free_energy_ids(model::MaxMinDrivingForceModel) =
     "ΔG " .* reaction_ids(model)
@@ -104,7 +104,7 @@ Accessors.gibbs_free_energy_variables(model::MaxMinDrivingForceModel) =
 Accessors.objective(model::MaxMinDrivingForceModel) =
     [1.0; fill(0.0, variable_count(model) - 1)]
 
-function Accessors.balance(model::MaxMinDrivingForceModel)
+function Accessors.metabolite_bounds(model::MaxMinDrivingForceModel)
     # proton water balance
     num_proton_water = length(model.proton_ids) + length(model.water_ids)
     proton_water_vec = spzeros(num_proton_water)
@@ -186,8 +186,8 @@ function Accessors.variable_bounds(model::MaxMinDrivingForceModel)
     ubs[1] = 1000.0
 
     # log concentrations
-    lbs[2:(1+n_metabolites(model))] .= log(model.concentration_lb)
-    ubs[2:(1+n_metabolites(model))] .= log(model.concentration_ub)
+    lbs[2:(1+metabolite_count(model))] .= log(model.concentration_lb)
+    ubs[2:(1+metabolite_count(model))] .= log(model.concentration_ub)
 
     # need to make special adjustments for the constants
     idxs = indexin([model.proton_ids; model.water_ids], var_ids)
@@ -212,12 +212,12 @@ function Accessors.coupling(model::MaxMinDrivingForceModel)
     end
 
     neg_dg_mat = [
-        spzeros(length(idxs)) spzeros(length(idxs), n_metabolites(model)) flux_signs
+        spzeros(length(idxs)) spzeros(length(idxs), metabolite_count(model)) flux_signs
     ]
 
     mmdf_mat = sparse(
         [
-            -ones(length(idxs)) spzeros(length(idxs), n_metabolites(model)) -flux_signs
+            -ones(length(idxs)) spzeros(length(idxs), metabolite_count(model)) -flux_signs
         ],
     )
 

--- a/src/wrappers/MinimizeDistance.jl
+++ b/src/wrappers/MinimizeDistance.jl
@@ -59,9 +59,10 @@ function Accessors.objective(m::MinimizeSemanticDistance)
     s = Accessors.Internal.semantics(m.semantics)
     M = s.mapping_matrix(m.inner)
 
-    return M *
-           [spdiagm(fill(-0.5, size(M, 2))) m.center] *
-           [M' zeros(size(M, 2)); zeros(size(M, 1))' 1.0]
+    # TODO check the validity of the math here
+    return M' *
+           [spdiagm(fill(-0.5, size(M, 1))) m.center] *
+           [M zeros(size(M, 1)); zeros(size(M, 2))' 1.0]
 end
 
 """

--- a/src/wrappers/SimplifiedEnzymeConstrainedModel.jl
+++ b/src/wrappers/SimplifiedEnzymeConstrainedModel.jl
@@ -84,8 +84,8 @@ Get the mapping of the reaction rates in
 wrapped model (as a matrix).
 """
 Accessors.reaction_variables_matrix(model::SimplifiedEnzymeConstrainedModel) =
-    simplified_enzyme_constrained_column_reactions(model)' *
-    reaction_variables_matrix(model.inner)
+    reaction_variables_matrix(model.inner) *
+    simplified_enzyme_constrained_column_reactions(model) #TODO check
 
 """
 $(TYPEDSIGNATURES)
@@ -96,8 +96,8 @@ wrapped model.
 """
 Accessors.reaction_variables(model::SimplifiedEnzymeConstrainedModel) =
     Accessors.Internal.make_mapping_dict(
-        variable_ids(model),
         reaction_ids(model.inner),
+        variable_ids(model),
         reaction_variables_matrix(model),
     ) # TODO currently inefficient
 

--- a/src/wrappers/misc/mmdf.jl
+++ b/src/wrappers/misc/mmdf.jl
@@ -20,4 +20,4 @@ $(TYPEDSIGNATURES)
 Helper function that returns the unmangled variable IDs.
 """
 original_variables(model::MaxMinDrivingForceModel) =
-    ["mmdf"; metabolites(model); reaction_ids(model)]
+    ["mmdf"; metabolite_ids(model); reaction_ids(model)]

--- a/test/io/h5.jl
+++ b/test/io/h5.jl
@@ -13,10 +13,10 @@
 
     # briefly test that the loading is okay
     @test variable_count(model) == variable_count(h5)
-    @test n_metabolites(model) == n_metabolites(h5)
+    @test metabolite_count(model) == metabolite_count(h5)
     @test issetequal(variable_ids(model), variable_ids(h5))
-    @test issetequal(metabolites(model), metabolites(h5))
-    @test issorted(metabolites(h5))
+    @test issetequal(metabolite_ids(model), metabolite_ids(h5))
+    @test issorted(metabolite_ids(h5))
     @test issorted(variable_ids(h5))
     @test size(stoichiometry(model)) == size(stoichiometry(h5))
     @test isapprox(sum(stoichiometry(model)), sum(stoichiometry(h5)))
@@ -24,7 +24,7 @@
     @test variable_bounds(model)[1][rxnp] == variable_bounds(h5)[1]
     @test variable_bounds(model)[2][rxnp] == variable_bounds(h5)[2]
     @test objective(model)[rxnp] == objective(h5)
-    @test all(iszero, balance(h5))
+    @test all(iszero, metabolite_bounds(h5))
 
     close(h5)
     @test isnothing(h5.h5)

--- a/test/io/json.jl
+++ b/test/io/json.jl
@@ -5,7 +5,7 @@
 
     # test if same reaction ids
     @test issetequal(variable_ids(jsonmodel), variable_ids(stdmodel))
-    @test issetequal(metabolites(jsonmodel), metabolites(stdmodel))
+    @test issetequal(metabolite_ids(jsonmodel), metabolite_ids(stdmodel))
     @test issetequal(genes(jsonmodel), genes(stdmodel))
     # not the best tests since it is possible that error could cancel each other out:
     @test sum(stoichiometry(jsonmodel)) == sum(stoichiometry(stdmodel))

--- a/test/io/mat.jl
+++ b/test/io/mat.jl
@@ -16,7 +16,7 @@ end
 
 @testset "Import yeast-GEM (mat)" begin
     m = load_model(ObjectModel, model_paths["yeast-GEM.mat"])
-    @test n_metabolites(m) == 2744
+    @test metabolite_count(m) == 2744
     @test reaction_count(m) == 4063
     @test n_genes(m) == 1160
 end

--- a/test/io/sbml.jl
+++ b/test/io/sbml.jl
@@ -4,13 +4,13 @@
     m = convert(MatrixModel, sbmlm)
 
     @test size(stoichiometry(sbmlm)) == (92, 95)
-    @test size(stoichiometry(m)) == (n_metabolites(sbmlm), variable_count(sbmlm))
+    @test size(stoichiometry(m)) == (metabolite_count(sbmlm), variable_count(sbmlm))
     @test length(m.S.nzval) == 380
     @test length.(variable_bounds(sbmlm)) == (95, 95)
     @test length.(variable_bounds(m)) == (95, 95)
     @test all([length(m.xl), length(m.xu), length(m.c)] .== 95)
 
-    @test metabolites(m)[1:3] == ["M_13dpg_c", "M_2pg_c", "M_3pg_c"]
+    @test metabolite_ids(m)[1:3] == ["M_13dpg_c", "M_2pg_c", "M_3pg_c"]
     @test reaction_ids(m)[1:3] == ["R_ACALD", "R_ACALDt", "R_ACKr"]
 
     cm = convert(MatrixModelWithCoupling, sbmlm)
@@ -27,7 +27,7 @@ end
 
 @testset "Import yeast-GEM (sbml)" begin
     m = load_model(ObjectModel, model_paths["yeast-GEM.xml"])
-    @test n_metabolites(m) == 2744
+    @test metabolite_count(m) == 2744
     @test reaction_count(m) == 4063
     @test n_genes(m) == 1160
 end

--- a/test/reconstruction/MatrixModel.jl
+++ b/test/reconstruction/MatrixModel.jl
@@ -119,7 +119,7 @@ end
         check_consistency = true,
     )
     @test variable_count(cp) == variable_count(new_cp)
-    @test n_metabolites(cp) + 1 == n_metabolites(new_cp)
+    @test metabolite_count(cp) + 1 == metabolite_count(new_cp)
 end
 
 @testset "Add reactions" begin
@@ -224,12 +224,12 @@ end
 
     modLp = remove_reactions(lp, [4; 1])
     @test stoichiometry(modLp) == stoichiometry(lp)[:, 2:3]
-    @test balance(modLp) == balance(lp)
+    @test metabolite_bounds(modLp) == metabolite_bounds(lp)
     @test objective(modLp) == objective(lp)[2:3]
     @test variable_bounds(modLp)[1] == variable_bounds(lp)[1][2:3]
     @test variable_bounds(modLp)[2] == variable_bounds(lp)[2][2:3]
     @test variable_ids(modLp) == variable_ids(lp)[2:3]
-    @test metabolites(modLp) == metabolites(lp)
+    @test metabolite_ids(modLp) == metabolite_ids(lp)
 end
 
 @testset "Remove metabolites" begin
@@ -237,17 +237,20 @@ end
 
     m1 = remove_metabolites(model, ["glc__D_e", "for_c"])
     m2 = remove_metabolite(model, "glc__D_e")
-    m3 = remove_metabolites(model, Int.(indexin(["glc__D_e", "for_c"], metabolites(model))))
-    m4 = remove_metabolite(model, first(indexin(["glc__D_e"], metabolites(model))))
+    m3 = remove_metabolites(
+        model,
+        Int.(indexin(["glc__D_e", "for_c"], metabolite_ids(model))),
+    )
+    m4 = remove_metabolite(model, first(indexin(["glc__D_e"], metabolite_ids(model))))
 
     @test size(stoichiometry(m1)) == (70, 90)
     @test size(stoichiometry(m2)) == (71, 93)
     @test size(stoichiometry(m3)) == (70, 90)
     @test size(stoichiometry(m4)) == (71, 93)
-    @test all((!in(metabolites(m1))).(["glc__D_e", "for_c"]))
-    @test !(["glc__D_e"] in metabolites(m2))
-    @test all((!in(metabolites(m3))).(["glc__D_e", "for_c"]))
-    @test !(["glc__D_e"] in metabolites(m4))
+    @test all((!in(metabolite_ids(m1))).(["glc__D_e", "for_c"]))
+    @test !(["glc__D_e"] in metabolite_ids(m2))
+    @test all((!in(metabolite_ids(m3))).(["glc__D_e", "for_c"]))
+    @test !(["glc__D_e"] in metabolite_ids(m4))
 end
 
 @testset "Core in place modifications" begin

--- a/test/reconstruction/ObjectModel.jl
+++ b/test/reconstruction/ObjectModel.jl
@@ -188,12 +188,12 @@
 
     # test added biomass metabolite
     new_model = model |> with_added_biomass_metabolite("r2")
-    @test "biomass" in metabolites(new_model)
-    @test !("biomass" in metabolites(model))
+    @test "biomass" in metabolite_ids(new_model)
+    @test !("biomass" in metabolite_ids(model))
     @test haskey(new_model.reactions["r2"].metabolites, "biomass")
     @test !haskey(model.reactions["r2"].metabolites, "biomass")
 
     new_model2 = new_model |> with_removed_biomass_metabolite("r2")
-    @test !("biomass" in metabolites(new_model2))
+    @test !("biomass" in metabolite_ids(new_model2))
     @test !haskey(new_model2.reactions["r2"].metabolites, "biomass")
 end

--- a/test/types/CommunityModel.jl
+++ b/test/types/CommunityModel.jl
@@ -184,7 +184,7 @@
 
     # test modification for community model
     res = flux_balance_analysis(cm, Tulip.Optimizer)
-    mb = res.result[:mb]
+    mb = res.result[:metabolite_eqs]
     x = res.result[:x]
     @test normalized_coefficient(mb[9], x[1]) == 0.2
     @test normalized_coefficient(mb[11], x[13]) == -0.8
@@ -194,7 +194,7 @@
         Tulip.Optimizer;
         modifications = [modify_abundances([0.5, 0.5])],
     )
-    mb = res2.result[:mb]
+    mb = res2.result[:metabolite_eqs]
     x = res2.result[:x]
     @test normalized_coefficient(mb[9], x[1]) == 0.5
     @test normalized_coefficient(mb[11], x[13]) == -0.5
@@ -218,7 +218,7 @@
         Tulip.Optimizer;
         modifications = [modify_abundances([0.3, 0.7])],
     )
-    mb = res3.result[:mb]
+    mb = res3.result[:metabolite_eqs]
     x = res3.result[:x]
     @test normalized_coefficient(mb[10], x[5]) == 0.3
     @test normalized_coefficient(mb[10], x[12]) == -0.3

--- a/test/types/CommunityModel.jl
+++ b/test/types/CommunityModel.jl
@@ -78,7 +78,7 @@
     )
 
     @test issetequal(
-        metabolites(cm),
+        metabolite_ids(cm),
         [
             "m1#A"
             "m1#B"
@@ -109,7 +109,7 @@
     )
 
     @test variable_count(cm) == 13
-    @test n_metabolites(cm) == 11
+    @test metabolite_count(cm) == 11
     @test n_genes(cm) == 8
 
     @test all(

--- a/test/types/ObjectModel.jl
+++ b/test/types/ObjectModel.jl
@@ -47,10 +47,10 @@
     @test contains(sprint(show, MIME("text/plain"), model), "ObjectModel")
 
     @test "r1" in variable_ids(model)
-    @test "m4" in metabolites(model)
+    @test "m4" in metabolite_ids(model)
     @test "g2" in genes(model)
     @test variable_count(model) == 4
-    @test n_metabolites(model) == 4
+    @test metabolite_count(model) == 4
     @test n_genes(model) == 3
 
     S_test = spzeros(4, 4)
@@ -78,7 +78,7 @@
     @test lb_test == lbs
     @test ub_test == ubs
 
-    @test balance(model) == spzeros(n_metabolites(model))
+    @test metabolite_bounds(model) == spzeros(metabolite_count(model))
 
     obj_test = spzeros(4)
     obj_test[1] = 1.0
@@ -134,7 +134,7 @@
     stdmodel = convert(ObjectModel, jsonmodel)
     @test issetequal(variable_ids(jsonmodel), variable_ids(stdmodel))
     @test issetequal(genes(jsonmodel), genes(stdmodel))
-    @test issetequal(metabolites(jsonmodel), metabolites(stdmodel))
+    @test issetequal(metabolite_ids(jsonmodel), metabolite_ids(stdmodel))
     jlbs, jubs = variable_bounds(jsonmodel)
     slbs, subs = variable_bounds(stdmodel)
     @test issetequal(jlbs, slbs)
@@ -143,10 +143,10 @@
     sS = stoichiometry(stdmodel)
     j_r1_index = findfirst(x -> x == "r1", variable_ids(jsonmodel))
     s_r1_index = findfirst(x -> x == "r1", variable_ids(stdmodel))
-    j_m1_index = findfirst(x -> x == "m1", metabolites(jsonmodel))
-    j_m2_index = findfirst(x -> x == "m2", metabolites(jsonmodel))
-    s_m1_index = findfirst(x -> x == "m1", metabolites(stdmodel))
-    s_m2_index = findfirst(x -> x == "m2", metabolites(stdmodel))
+    j_m1_index = findfirst(x -> x == "m1", metabolite_ids(jsonmodel))
+    j_m2_index = findfirst(x -> x == "m2", metabolite_ids(jsonmodel))
+    s_m1_index = findfirst(x -> x == "m1", metabolite_ids(stdmodel))
+    s_m2_index = findfirst(x -> x == "m2", metabolite_ids(stdmodel))
     @test jS[j_m1_index, j_r1_index] == sS[s_m1_index, s_r1_index]
     @test jS[j_m2_index, j_r1_index] == sS[s_m2_index, s_r1_index]
 end

--- a/test/types/SBMLModel.jl
+++ b/test/types/SBMLModel.jl
@@ -6,7 +6,7 @@
 
     @test Set(variable_ids(sbmlm)) == Set(variable_ids(sbmlm2))
     @test Set(variable_ids(sbmlm)) == Set(variable_ids(sm))
-    @test Set(metabolites(sbmlm)) == Set(metabolites(sbmlm2))
+    @test Set(metabolite_ids(sbmlm)) == Set(metabolite_ids(sbmlm2))
     sp(x) = x.species
     @test all([
         issetequal(

--- a/test/types/abstract/AbstractMetabolicModel.jl
+++ b/test/types/abstract/AbstractMetabolicModel.jl
@@ -6,7 +6,7 @@ end
 @testset "Base abstract model methods require proper minimal implementation" begin
     @test_throws MethodError variable_ids(123)
     x = FakeModel(123)
-    for m in [variables, metabolites, stoichiometry, bounds, objective]
+    for m in [variable_ids, variable_bounds, objective]
         @test_throws MethodError m(x)
     end
 end

--- a/test/types/abstract/AbstractMetabolicModel.jl
+++ b/test/types/abstract/AbstractMetabolicModel.jl
@@ -13,8 +13,10 @@ end
 
 
 @testset "ID shortcuts are identictical with the ID-generating functions" begin
+    # this is better triple-checked to avoid someone stealing the overloads
     @test variables === variable_ids
     @test bounds === variable_bounds
     @test reactions === reaction_ids
-    # TODO don't forget about metabolites later
+    @test metabolites === metabolite_ids
+    @test stoichiometry === metabolite_variables_matrix
 end

--- a/test/utils/MatrixModel.jl
+++ b/test/utils/MatrixModel.jl
@@ -1,7 +1,7 @@
 @testset "MatrixModel utilities" begin
     cp = test_LP()
     @test variable_count(cp) == 3
-    @test n_metabolites(cp) == 4
+    @test metabolite_count(cp) == 4
     @test n_coupling_constraints(cp) == 0
 
     cp2 = test_LP()

--- a/test/utils/Serialized.jl
+++ b/test/utils/Serialized.jl
@@ -19,7 +19,7 @@
     )
     sm.m = nothing
     @test issetequal(
-        metabolites(convert(MatrixModelWithCoupling, sm)),
-        metabolites(convert(MatrixModelWithCoupling, sm2)),
+        metabolite_ids(convert(MatrixModelWithCoupling, sm)),
+        metabolite_ids(convert(MatrixModelWithCoupling, sm2)),
     )
 end

--- a/test/utils/looks_like.jl
+++ b/test/utils/looks_like.jl
@@ -41,7 +41,8 @@
         x -> looks_like_exchange_reaction(x; exclude_biomass = true),
         variable_ids(cp),
     ) == ["EX_m1(e)", "EX_m3(e)"]
-    @test filter(looks_like_extracellular_metabolite, metabolites(cp)) == ["m1[e]", "m3[e]"]
+    @test filter(looks_like_extracellular_metabolite, metabolite_ids(cp)) ==
+          ["m1[e]", "m3[e]"]
     @test filter(looks_like_biomass_reaction, variable_ids(cp)) ==
           ["EX_biomass(e)", "biomass1"]
     @test filter(
@@ -54,27 +55,27 @@ end
     model = load_model(model_paths["e_coli_core.json"])
     @test length(filter(looks_like_exchange_reaction, variable_ids(model))) == 20
     @test length(filter(looks_like_biomass_reaction, variable_ids(model))) == 1
-    @test length(filter(looks_like_extracellular_metabolite, metabolites(model))) == 20
+    @test length(filter(looks_like_extracellular_metabolite, metabolite_ids(model))) == 20
 
     model = load_model(model_paths["e_coli_core.xml"])
     @test length(filter(looks_like_exchange_reaction, variable_ids(model))) == 20
     @test length(filter(looks_like_biomass_reaction, variable_ids(model))) == 1
-    @test length(filter(looks_like_extracellular_metabolite, metabolites(model))) == 20
+    @test length(filter(looks_like_extracellular_metabolite, metabolite_ids(model))) == 20
 
     model = load_model(model_paths["e_coli_core.mat"])
     @test length(filter(looks_like_exchange_reaction, variable_ids(model))) == 20
     @test length(filter(looks_like_biomass_reaction, variable_ids(model))) == 1
-    @test length(filter(looks_like_extracellular_metabolite, metabolites(model))) == 20
+    @test length(filter(looks_like_extracellular_metabolite, metabolite_ids(model))) == 20
 
     model = convert(ObjectModel, model)
     @test length(filter(looks_like_exchange_reaction, variable_ids(model))) == 20
     @test length(filter(looks_like_biomass_reaction, variable_ids(model))) == 1
-    @test length(filter(looks_like_extracellular_metabolite, metabolites(model))) == 20
+    @test length(filter(looks_like_extracellular_metabolite, metabolite_ids(model))) == 20
 
     model = convert(MatrixModelWithCoupling, model)
     @test length(filter(looks_like_exchange_reaction, variable_ids(model))) == 20
     @test length(filter(looks_like_biomass_reaction, variable_ids(model))) == 1
-    @test length(filter(looks_like_extracellular_metabolite, metabolites(model))) == 20
+    @test length(filter(looks_like_extracellular_metabolite, metabolite_ids(model))) == 20
 end
 
 @testset "Ontology usage in is_xxx_reaction" begin


### PR DESCRIPTION
I have this specially separated from the rest of the (RELATIVELY HARMLESS) semantics-are-everywhere change because it's gonna be the most breaking part, and the reviews should be kinda clear.

In this state it's not looking good (tests will fail until I fix them) but most of the errors I see seem fixable.

As the main points:
- `stoichiometry` is now just a nice name for `metabolite_variables_matrix`
- `balance` is gone, instead of that the metabolites have the balance bounds
- stoichiometry is no more matrixy "by default", the dictionary-ish `metabolite_variables` is the master form now as with other semantics..
  - pros: resizing variables or reactions doesn't kill stoichiometry and you don't need to care about that much
  - cons: reconstructing the stoichiometry from dicts isn't that nicely efficient, we'll need a bit of extra annotations to be able to pipe the matrixy form through wrappers easily
  
I'll fix the rest, at this points any comments welcome.